### PR TITLE
Fixing the link for Issue filing.

### DIFF
--- a/E2E/Documents/WSE e2e Automation Test Usage Guide.txt
+++ b/E2E/Documents/WSE e2e Automation Test Usage Guide.txt
@@ -27,7 +27,7 @@ WSE e2e Automation Test Usage Guidelines
  
 7. Reporting Issues and Bug filling:
 For Non-Microsoft Users
-Issue reporting link: https://github.com/WSETests/AutomationScripts/issues/new?template=Blank+issue
+Issue reporting link: https://github.com/microsoft/WSEAutomationTests/issues
 
 For Microsoft Internal Users
 Bug filing link: https://microsoft.visualstudio.com/OS/_workitems/create/Bug

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,7 +8,7 @@ feature request as a new Issue.
 
 Reporting Issues and Bug filling:
 For Non-Microsoft Users
-Issue reporting link: https://github.com/WSETests/AutomationScripts/issues/new?template=Blank+issue
+Issue reporting link: https://github.com/microsoft/WSEAutomationTests/issues
 
 For Microsoft Internal Users
 Bug filing link: https://microsoft.visualstudio.com/OS/_workitems/create/Bug


### PR DESCRIPTION
What: Fixing the link for Issue filing.

Why: Accidently copied the wrong link. 

