### PR TITLE
[MEP Automation] to leverage 'FriendlyName' from DxDiag for e2e testing

### DIFF
--- a/E2E/CheckInTest/RevisitCameraSettingPage.ps1
+++ b/E2E/CheckInTest/RevisitCameraSettingPage.ps1
@@ -38,15 +38,8 @@ function RevisitCameraSetting($times)
           ClickFrontCamera $ui Button More
       }
       else
-      {   
-          $propertyNameList = @(
-          'Connected enabled camera Surface Camera Front',
-          'Connected enabled camera OV01AS',
-          'Connected enabled camera ASUS FHD webcam'
-          'Connected enabled camera HP 9MP Camera'
-          'Connected enabled camera Integrated Camera'
-          )
-          FindAndClickList $ui Button $propertyNameList
+      {
+          FindAndClick $ui Button "Connected enabled camera $Global:validatedCameraFriendlyName"
       }  
        Start-Sleep -s 2
        $i++

--- a/E2E/Helper/InitializeTest.ps1
+++ b/E2E/Helper/InitializeTest.ps1
@@ -19,6 +19,7 @@ function InitializeTest($TstsetNme, $targetMepCameraVer, $targetMepAudioVer, $ta
     New-Item -ItemType Directory -Force -Path $pathLogsFolder  | Out-Null
     $Global:SequenceNumber = 0
     $Global:Results = '' | SELECT ScenarioName,FramesAbove33ms,AvgProcessingTimePerFrame,MaxProcessingTimePerFrame,MinProcessingTimePerFrame,PCInItTime,CameraAppInItTime,VoiceRecorderInItTime,fps,PCInItTimeForAudio,FramesAbove33msForAudioBlur,PeakWorkingSetSize,AvgWorkingSetSize,Status,ReasonForNotPass
+    $Global:validatedCameraFriendlyName = ""
 
     # once if the WseEnabingStatus validation fails, stop and exit the test
     if ((WseEnablingStatus $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer) -eq $false)

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -23,15 +23,8 @@ function FindCameraEffectsPage($uiEle){
         ClickFrontCamera $uiEle Button More
     }
     else
-    {   
-        $propertyNameList = @(
-        'Connected enabled camera Surface Camera Front',
-        'Connected enabled camera OV01AS',
-        'Connected enabled camera ASUS FHD webcam'
-        'Connected enabled camera HP 9MP Camera'
-        'Connected enabled camera Integrated Camera'
-        )
-        FindAndClickList $uiEle Button $propertyNameList
+    {
+        FindAndClick $uiEle Button "Connected enabled camera $Global:validatedCameraFriendlyName"
     }  
     Start-Sleep -m 500
 }

--- a/E2E/Library/WseEnablingStatus.ps1
+++ b/E2E/Library/WseEnablingStatus.ps1
@@ -210,6 +210,7 @@ function WseEnablingStatus($targetMepCameraVer, $targetMepAudioVer, $targetPerce
 
 	if ($optinCameraFriendlyName) {
 		outputMessage "Opt-In Camera FriendlyName: $optinCameraFriendlyName"
+		$Global:validatedCameraFriendlyName = $optinCameraFriendlyName
 	} else {
 		Write-Host "Opt-In Camera FriendlyName Info not found"
 	}


### PR DESCRIPTION
What: In the WseEnablingStatus function, we have retrieved the 'FriendlyName' of the validated camera. We can use this information to directly access the camera in the Settings page.

Why: We are not able to enumerate all the friendly names of OEM cameras, and DxDiag to provide a way to overcome this.

## What changed?


## How did you test the change?


## Related Issues (if any):

