### PR TITLE
Added param for totalNoofFrames and Added new parameter (VF) for failed tests

### DIFF
--- a/E2E/Helper/InitializeTest.ps1
+++ b/E2E/Helper/InitializeTest.ps1
@@ -3,13 +3,11 @@ DESCRIPTION:
     This function initializes the environment for a test run. It sets up global variables 
     for log storage, initializes result tracking structures, and validates the 
     WSE (Windows Subsystem for Enhanced) enabling status based on specified target versions.
-
 INPUT PARAMETERS:
     - TstsetNme [string] :- The name of the test set, used for naming log folders.
     - targetMepCameraVer [string] :- The target version of the MEP Camera component to be validated.
     - targetMepAudioVer [string] :- The target version of the MEP Audio component to be validated.
     - targetPerceptionCoreVer [string] :- The target version of the Perception Core component to be validated.
-
 RETURN TYPE:
     - void
 #>
@@ -18,7 +16,7 @@ function InitializeTest($TstsetNme, $targetMepCameraVer, $targetMepAudioVer, $ta
     $Global:pathLogsFolder = ".\Logs\" + "$((get-date).tostring('yyyy-MM-dd-HH-mm-ss'))" + "-$TstsetNme"
     New-Item -ItemType Directory -Force -Path $pathLogsFolder  | Out-Null
     $Global:SequenceNumber = 0
-    $Global:Results = '' | SELECT ScenarioName,FramesAbove33ms,AvgProcessingTimePerFrame,MaxProcessingTimePerFrame,MinProcessingTimePerFrame,PCInItTime,CameraAppInItTime,VoiceRecorderInItTime,fps,PCInItTimeForAudio,FramesAbove33msForAudioBlur,PeakWorkingSetSize,AvgWorkingSetSize,Status,ReasonForNotPass
+    $Global:Results = '' | SELECT ScenarioName,FramesAbove33ms,TotalNumberOfFrames,AvgProcessingTimePerFrame,MaxProcessingTimePerFrame,MinProcessingTimePerFrame,PCInItTime,CameraAppInItTime,VoiceRecorderInItTime,fps,PCInItTimeForAudio,FramesAbove33msForAudioBlur,PeakWorkingSetSize,AvgWorkingSetSize,Status,ReasonForNotPass
     $Global:validatedCameraFriendlyName = ""
 
     # once if the WseEnabingStatus validation fails, stop and exit the test

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -196,13 +196,13 @@ function AddToFailedTestsList($failedTests)
    $togAiEfft = $splitEachTests[6]
    $token = "111222"
    $SPID ="333444"
-   if($functionToCall -eq  "CameraAppTest")
+if($functionToCall -eq  "CameraAppTest")
    {
-      write-output "$functionToCall -logFile $logFile $token $SPId -camsnario $camsnario -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -VF $VF -toggleEachAiEffect $togAiEfft >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
-      write-output $failedTests >> $pathLogsFolder\failedTests.txt
+      Write-Log -Message "$functionToCall -logFile $logFile $token $SPId -camsnario $camsnario -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> `$pathLogsFolder\CameraAppTest.txt" -IsOutput >> $pathLogsFolder\ReRunFailedTests.ps1
+      Write-Log -Message $failedTests -IsOutput >> $pathLogsFolder\failedTests.txt
    }
    else
    {
-      write-output $failedTests >> $pathLogsFolder\failedTests.txt
+      Write-Log -Message $failedTests -IsOutput >> $pathLogsFolder\failedTests.txt
    }
 }

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -83,6 +83,7 @@ RETURN TYPE:
 function ResetFields {
    $Results.ScenarioName = $null
    $Results.FramesAbove33ms = $null
+   $Results.TotalNumberOfFrames = $null 								   
    $Results.AvgProcessingTimePerFrame =$null
    $Results.MaxProcessingTimePerFrame =$null
    $Results.MinProcessingTimePerFrame =$null
@@ -190,16 +191,18 @@ function AddToFailedTestsList($failedTests)
    $vdoRes = $splitEachTests[2]
    $ptoRes = $splitEachTests[3]
    $devPowStat = $splitEachTests[4]
-   $togAiEfft = $splitEachTests[5]
+   $VFdetails  = $splitEachTests[5] -split "-"
+   $VF = $VFdetails[1]
+   $togAiEfft = $splitEachTests[6]
    $token = "111222"
    $SPID ="333444"
    if($functionToCall -eq  "CameraAppTest")
    {
-      Write-Log -Message "$functionToCall -logFile $logFile $token $SPId -camsnario $camsnario -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> `$pathLogsFolder\CameraAppTest.txt" -IsOutput >> $pathLogsFolder\ReRunFailedTests.ps1
-      Write-Log -Message $failedTests -IsOutput >> $pathLogsFolder\failedTests.txt
+      write-output "$functionToCall -logFile $logFile $token $SPId -camsnario $camsnario -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -VF $VF -toggleEachAiEffect $togAiEfft >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
+      write-output $failedTests >> $pathLogsFolder\failedTests.txt
    }
    else
    {
-      Write-Log -Message $failedTests -IsOutput >> $pathLogsFolder\failedTests.txt
+      write-output $failedTests >> $pathLogsFolder\failedTests.txt
    }
 }

--- a/E2E/Library/VerifyLogs.ps1
+++ b/E2E/Library/VerifyLogs.ps1
@@ -73,6 +73,7 @@ function VerifyLogs($snarioName, $snarioId, $strtTime)
           
           #Reading log file to get frames Processing time details
           $numberOfFramesAbove33ms = $frameProcessingDetails[20].Trim()
+		    $totalnoOfFrames = $frameProcessingDetails[9].Trim()
           $minProcessingTimePerFrame = [math]::round(($frameProcessingDetails[12]/1000000),2)
           $avgProcessingTimePerFrame = [math]::round(($frameProcessingDetails[11]/1000000),2)
           $maxProcessingTimePerFrame = [math]::round(($frameProcessingDetails[13]/1000000),2)
@@ -83,7 +84,8 @@ function VerifyLogs($snarioName, $snarioId, $strtTime)
 
           $Results.ScenarioName = $snarioName
           $Results.FramesAbove33ms = $numberOfFramesAbove33ms
-          $Results.AvgProcessingTimePerFrame = "${avgProcessingTimePerFrame}ms"
+		    $Results.TotalNumberOfFrames = $totalnoOfFrames
+		    $Results.AvgProcessingTimePerFrame = "${avgProcessingTimePerFrame}ms"
           $Results.MaxProcessingTimePerFrame = "${maxProcessingTimePerFrame}ms"
           $Results.MinProcessingTimePerFrame = "${minProcessingTimePerFrame}ms"
           
@@ -419,7 +421,8 @@ function CheckMemoryUsage($snarioName)
          if ( $avgWorkingSetSize -ge 250 )
          {   
             #Prints to the console if $avgWorkingSetSize is greater than or equal to 250MBs
-            Write-Log -Message "AvgWorkingSetSize is greater than 250MBs [PrivateUsage:${privateUsage}MBs, PeakWorkingSetSize:${peakWorkingSetSize}MBs, PageFaultCount:${pageFaultCount}, AvgWorkingSetSize:${avgWorkingSetSize}MBs]" -IsOutput -IsHost -BackgroundColor Red >> $pathLogsFolder\ConsoleResults.txt
+            Write-Host "   AvgWorkingSetSize is greater than 250MBs [PrivateUsage:${privateUsage}MBs, PeakWorkingSetSize:${peakWorkingSetSize}MBs, PageFaultCount:${pageFaultCount} , AvgWorkingSetSize:${avgWorkingSetSize}MBs] " -BackgroundColor Red
+            Write-Log -Message "AvgWorkingSetSize is greater than 250MBs [PrivateUsage:${privateUsage}MBs, PeakWorkingSetSize:${peakWorkingSetSize}MBs, PageFaultCount:${pageFaultCount}, AvgWorkingSetSize:${avgWorkingSetSize}MBs]" -IsOutput >> $pathLogsFolder\ConsoleResults.txt
             Write-Log -Message "AsgTraceLog saved here: $pathAsgTraceLogs" -IsHost -IsOutput >> $pathLogsFolder\ConsoleResults.txt
          }
          $i++

--- a/E2E/Library/VerifyLogs.ps1
+++ b/E2E/Library/VerifyLogs.ps1
@@ -73,7 +73,7 @@ function VerifyLogs($snarioName, $snarioId, $strtTime)
           
           #Reading log file to get frames Processing time details
           $numberOfFramesAbove33ms = $frameProcessingDetails[20].Trim()
-		    $totalnoOfFrames = $frameProcessingDetails[9].Trim()
+		  $totalnoOfFrames = $frameProcessingDetails[9].Trim()
           $minProcessingTimePerFrame = [math]::round(($frameProcessingDetails[12]/1000000),2)
           $avgProcessingTimePerFrame = [math]::round(($frameProcessingDetails[11]/1000000),2)
           $maxProcessingTimePerFrame = [math]::round(($frameProcessingDetails[13]/1000000),2)
@@ -84,8 +84,8 @@ function VerifyLogs($snarioName, $snarioId, $strtTime)
 
           $Results.ScenarioName = $snarioName
           $Results.FramesAbove33ms = $numberOfFramesAbove33ms
-		    $Results.TotalNumberOfFrames = $totalnoOfFrames
-		    $Results.AvgProcessingTimePerFrame = "${avgProcessingTimePerFrame}ms"
+		  $Results.TotalNumberOfFrames = $totalnoOfFrames
+		  $Results.AvgProcessingTimePerFrame = "${avgProcessingTimePerFrame}ms"
           $Results.MaxProcessingTimePerFrame = "${maxProcessingTimePerFrame}ms"
           $Results.MinProcessingTimePerFrame = "${minProcessingTimePerFrame}ms"
           
@@ -421,8 +421,7 @@ function CheckMemoryUsage($snarioName)
          if ( $avgWorkingSetSize -ge 250 )
          {   
             #Prints to the console if $avgWorkingSetSize is greater than or equal to 250MBs
-            Write-Host "   AvgWorkingSetSize is greater than 250MBs [PrivateUsage:${privateUsage}MBs, PeakWorkingSetSize:${peakWorkingSetSize}MBs, PageFaultCount:${pageFaultCount} , AvgWorkingSetSize:${avgWorkingSetSize}MBs] " -BackgroundColor Red
-            Write-Log -Message "AvgWorkingSetSize is greater than 250MBs [PrivateUsage:${privateUsage}MBs, PeakWorkingSetSize:${peakWorkingSetSize}MBs, PageFaultCount:${pageFaultCount}, AvgWorkingSetSize:${avgWorkingSetSize}MBs]" -IsOutput >> $pathLogsFolder\ConsoleResults.txt
+            Write-Log -Message "AvgWorkingSetSize is greater than 250MBs [PrivateUsage:${privateUsage}MBs, PeakWorkingSetSize:${peakWorkingSetSize}MBs, PageFaultCount:${pageFaultCount}, AvgWorkingSetSize:${avgWorkingSetSize}MBs]" -IsOutput -IsHost -BackgroundColor Red >> $pathLogsFolder\ConsoleResults.txt
             Write-Log -Message "AsgTraceLog saved here: $pathAsgTraceLogs" -IsHost -IsOutput >> $pathLogsFolder\ConsoleResults.txt
          }
          $i++


### PR DESCRIPTION
## What changed?
1)Added a column for the total number of frames processed in each scenario within the Report.
2)Added parameter for voice focus in AddToFailedTestsList function.

Why: 
1)While this data has always been captured in asgtrace, it was previously missing from the Report. Including it in the Excel Report improves readability and accessibility of the information.
2)With the recent changes in ReleaseTest ps1. we have added the functionality to run the tests with voice focus too and that parameter was missing in "RerunfailedTest.ps1"

## How did you test the change? 
1)Validated the change on Cadmus by generating the Report and confirming that the new column was correctly added.
2) Tested the code on cadmus device with pluggedIn scenario.

These two changes were already merged to MEP repo, pulling the changes from there.
## Related Issues (if any):

