### PR TITLE
Create Individual file for each test scenario in SettingApp ps1

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -198,9 +198,9 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
         CloseApp 'Taskmgr'
         StopTrace $scenarioLogFolder
         CheckServiceState 'Windows Camera Frame Server'
-        Write-Log -Message $_ -IsOutput
+        Write-Output $_
         TestOutputMessage $scenarioLogFolder "Exception" $startTime $_.Exception.Message
-        Write-Log -Message "$_" -IsOutput >> $pathLogsFolder\ConsoleResults.txt
+        Write-Output $_ >> $pathLogsFolder\ConsoleResults.txt
         Reporting $Results "$pathLogsFolder\Report.txt"
         GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioLogFolder
         $getLogs = Get-Content -Path "$pathLogsFolder\$scenarioLogFolder\log.txt" -raw
@@ -213,22 +213,4 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
     }                                
 }
 
-<#
-DESCRIPTION:
-    Copies log file content to a test-specific folder. It extracts relevant logs from the main log file
-    starting from the most recent test instance and saves them in a dedicated test-specific log file.
-INPUT PARAMETERS:
-    - scenarioLogFldr [string] :- The name of the scenario-specific folder where logs should be copied.
-RETURN TYPE:
-    - void
-#>
-function GetContentOfLogFileAndCopyToTestSpecificLogFile($scenarioLogFldr)
-{   
-    #copy logs to test specific folder
-    $logCopyFrom = "$pathLogsFolder\$logFile"
-    $logCopyTo =  "$pathLogsFolder\$scenarioLogFldr\log.txt" 
-    $search="Starting Test for "
-    $linenumber = Get-Content $logCopyFrom | select-string $search | Select-Object -Last 1
-    $lne = $linenumber.LineNumber - 1
-    Get-Content -Path $logCopyFrom | Select -Skip $lne > $logCopyTo 
-}
+   

--- a/E2E/CheckInTest/SettingAppTest.ps1
+++ b/E2E/CheckInTest/SettingAppTest.ps1
@@ -34,7 +34,7 @@ function SettingAppTest-Playlist($devPowStat, $testScenario, $token, $SPId)
        Write-Log -Message "Creating folder for capturing logs" -IsOutput
        CreateScenarioLogsFolder $scenarioName
 
-       Write-Log -Message "Start Tests for $scenarioName" -IsOutput
+       Write-Log -Message "Starting Test for $scenarioName" -IsOutput
        
        # Retrieve value for scenario from LookUp table for camera effects
        $testScenario = RetrieveValue $testScenario
@@ -127,13 +127,34 @@ function SettingAppTest-Playlist($devPowStat, $testScenario, $token, $SPId)
        # Verify and validate if proper logs are generated or not.
        Write-Log -Message "Entering Verifylogs function" -IsOutput
        Verifylogs $scenarioName $scenarioID $startTime
-       
+
+       # Copy logs to test scenario specific folder
+       Write-Log -Message "Entering GetContentOfLogFileAndCopyToTestSpecificLogFile function" -IsOutput
+       GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioName
+             
        #collect data for Reporting
        Reporting $Results "$pathLogsFolder\Report.txt"
          
      }
      catch
      {  
-        Error-Exception -snarioName $scenarioName -strttme $startTime -rslts $Results -logFile $logFile -token $token -SPID $SPID
+        Take-Screenshot "Error-Exception" $scenarioName
+        Write-Log -Message "Error occurred and entered catch statement" -IsOutput
+        CloseApp 'systemsettings'
+        CloseApp 'WindowsCamera'
+        CloseApp 'Taskmgr'
+        StopTrace $scenarioName
+        CheckServiceState 'Windows Camera Frame Server'
+        Write-Output $_
+        TestOutputMessage $scenarioName "Exception" $startTime $_.Exception.Message
+        Write-Output $_ >> $pathLogsFolder\ConsoleResults.txt
+        Reporting $Results "$pathLogsFolder\Report.txt"
+        GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioName
+        $getLogs = Get-Content -Path "$pathLogsFolder\$scenarioName\log.txt" -Raw
+        Write-Log -Message $getLogs -IsHost
+        $logs = resolve-path "$pathLogsFolder\$scenarioName\log.txt"
+        Write-Log -Message "(Logs saved here:$logs)" -IsHost
+        SetSmartPlugState $token $SPID 1
      }
+                 
 }

--- a/E2E/Helper/SetAsgTraceFolders.ps1
+++ b/E2E/Helper/SetAsgTraceFolders.ps1
@@ -17,3 +17,22 @@ function CreateScenarioLogsFolder ($snario)
         New-Item -ItemType Directory -Force -Path $scenarioLogsFolder  | Out-Null
     }
 }
+<#
+DESCRIPTION:
+    Copies log file content to a test-specific folder. It extracts relevant logs from the main log file
+    starting from the most recent test instance and saves them in a dedicated test-specific log file.
+INPUT PARAMETERS:
+    - scenarioLogFldr [string] :- The name of the scenario-specific folder where logs should be copied.
+RETURN TYPE:
+    - void
+#>
+function GetContentOfLogFileAndCopyToTestSpecificLogFile($scenarioLogFldr)
+{   
+    #copy logs to test specific folder
+    $logCopyFrom = "$pathLogsFolder\$logFile"
+    $logCopyTo =  "$pathLogsFolder\$scenarioLogFldr\log.txt" 
+    $search="Starting Test for "
+    $linenumber = Get-Content $logCopyFrom | select-string $search | Select-Object -Last 1
+    $lne = $linenumber.LineNumber - 1
+    Get-Content -Path $logCopyFrom | Select -Skip $lne > $logCopyTo 
+}

--- a/E2E/Library/ExceptionError.ps1
+++ b/E2E/Library/ExceptionError.ps1
@@ -23,17 +23,14 @@ function Error-Exception($snarioName, $strttme, $rslts, $logFile, $token, $SPID)
    CloseApp 'Taskmgr'
    StopTrace $snarioName
    CheckServiceState 'Windows Camera Frame Server'
-
-   Write-Log -Message $_ -IsOutput
+   Write-Output $_
    TestOutputMessage $snarioName "Exception" $strttme $_.Exception.Message
-
-   Write-Log -Message $_ -IsOutput >> $pathLogsFolder\ConsoleResults.txt
+   Write-Output $_ >> $pathLogsFolder\ConsoleResults.txt
    Reporting $rslts "$pathLogsFolder\Report.txt"
    $getLogs = Get-Content -Path "$pathLogsFolder\$logFile" -Raw
    Write-Log -Message $getLogs -IsHost
-
    $logs = resolve-path "$pathLogsFolder\$logFile"
    Write-Log -Message "(Logs saved here:$logs)" -IsHost
-
    SetSmartPlugState $token $SPID 1
 }
+ 


### PR DESCRIPTION
## What changed?
Added functionality to add individual log file under test specific scenario for SettingApp ps1.
image.png
## Why changed?
 Earlier all camera setting scenarios were executed as individual ps1 and individual log file was generated for each scenario, currently all scenarios are executed through single ps1 leading to generate single log file. This leads to issue when the test fails, complete logs are printed to console which includes all scenarios instead of test specific scenario.
## How did you test the change?
Tested on AsusProArt.
## Related Issues (if any):

