### PR TITLE
Update release tests

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -39,21 +39,21 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
           TestOutputMessage $scenarioLogFolder "Skipped" $startTime "wsev2Policy Not Supported"
           return
        }
+
+       #Set the device Power state
+       #if token and SPid is available than run scenarios for both pluggedin and unplugged 
+       Write-Output "Start Tests for $devPowStat scenario" 
+       $devState = CheckDevicePowerState $devPowStat $token $SPId
+       if($devState -eq $false)
+       {   
+          TestOutputMessage  $scenarioLogFolder "Skipped" $startTime "Token is empty"  
+          return
+       }  
        
        if($initSetUpDone -ne "true")
        {
           # Open Camera App and set default setting to "Use system settings" 
           Set-SystemSettingsInCamera
-         
-          #Set the device Power state
-          #if token and SPid is available than run scenarios for both pluggedin and unplugged 
-          Write-Output "Start Tests for $devPowStat scenario" 
-          $devState = CheckDevicePowerState $devPowStat $token $SPId
-          if($devState -eq $false)
-          {   
-             TestOutputMessage  $scenarioLogFolder "Skipped" $startTime "Token is empty"  
-             return
-          }  
           
           #Open system setting page and toggle voice focus 
           if($VF -ne "NA")

--- a/E2E/Library/SmartPlug.ps1
+++ b/E2E/Library/SmartPlug.ps1
@@ -177,3 +177,23 @@ function Get-BatteryPercentage {
    $battery = Get-WmiObject -Query "Select * from Win32_Battery"
    return $battery.EstimatedChargeRemaining
 }
+
+<#
+DESCRIPTION:
+    This function returns the current charging state.
+INPUT PARAMETERS:
+    - None
+RETURN TYPE:
+    - [string] (Returns battery state: charging or discharging or unknown.)
+#>
+function Get-ChargingState {
+    $batteryStatus = Get-WmiObject -Class Win32_Battery | Select-Object -ExpandProperty BatteryStatus
+ 
+    if ($batteryStatus -eq 2) {
+        return "Charging"
+    } elseif ($batteryStatus -eq 1) {
+        return "Discharging"
+    } else {
+        return "Unknown"
+    }
+}

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -3,7 +3,8 @@
    [string] $SPId = $null,
    [string] $targetMepCameraVer = $null,
    [string] $targetMepAudioVer = $null,
-   [string] $targetPerceptionCoreVer = $null
+   [string] $targetPerceptionCoreVer = $null,
+   [ValidateSet("Both", "PluggedInOnly", "UnpluggedOnly")][string] $runMode = $null
 )
 .".\CheckInTest\Helper-library.ps1"
 InitializeTest 'ReleaseTest' $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer
@@ -63,45 +64,114 @@ foreach($camsnario in $deviceData["CameraScenario"])
             $unpluggedLast = -1
             $pluggedInLast = -1
 
-            <#
-            Approach we follow to run all the tests:
-               1. Battery Check: At the start, the battery status is checked.
-               2. Unplugged Scenarios: If the battery is above 20%, the Unplugged scenarios will run. If the battery drops below 20% during the 
-                  Unplugged scenarios, the device is immediately plugged in for charging.
-               3. Plugged-in Scenarios: We start executing pluggedIn tests during this state. This is done until either we complete all unplugged 
-                  state tests, or we reach 80% charge.
-               4. Unplugged Scenarios Continuation: Once either of the above-mentioned state is attained, the remaining Unplugged scenarios are executed.
-               5. This loop continues until both the unplugged and pluggedIn tests are completed.
-            #>
             while ($true) {
                $batteryPercentage = Get-BatteryPercentage
+               $chargingState = Get-ChargingState  # Fetch current charging state
 
-               if ($batteryPercentage -lt 20) {
-                  while ($batteryPercentage -lt 80 -and $pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
-                     $pluggedInLast++
-                     $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
-                     $devPowStat = "PluggedIn"
+               <#
+               Approach we follow to run all the tests (pluggedin + unplugged) when smart plug details are provided along with run mode = Both or null (null meaning not provided):
+                  1. Battery Check: At the start, the battery status is checked.
+                  2. Unplugged Scenarios: If the battery is above 20%, the Unplugged scenarios will run. If the battery drops below 20% during the 
+                     Unplugged scenarios, the device is immediately plugged in for charging.
+                  3. Plugged-in Scenarios: We start executing pluggedIn tests during this state. This is done until either we complete all unplugged 
+                     state tests, or we reach 80% charge.
+                  4. Unplugged Scenarios Continuation: Once either of the above-mentioned state is attained, the remaining Unplugged scenarios are executed.
+                  5. This loop continues until both the unplugged and pluggedIn tests are completed.
+               #>
+               if ($token -and $SPId -and ($runMode -eq "Both" -or [string]::IsNullOrEmpty($runMode))) {
+                  if ($batteryPercentage -lt 20) {
+                     while ($batteryPercentage -lt 80 -and $pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
+                        $pluggedInLast++
+                        $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
+                        $devPowStat = "PluggedIn"
+                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                        $batteryPercentage = Get-BatteryPercentage
+                     }
+                  } else {
+                     if ($unpluggedLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
+                        $unpluggedLast++
+                        $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
+                        $devPowStat = "Unplugged"
+                     } else {
+                        $pluggedInLast++
+                        $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
+                        $devPowStat = "PluggedIn"
+                     }
                      CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
-                     $batteryPercentage = Get-BatteryPercentage
                   }
-               } else {
+
+                  if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
+                     Write-Host "breaking from the while loop"
+                     break
+                  }
+               }
+
+               <#
+               Approach we follow to run only unplugged tests:
+                  1. Run unplugged tests only when the run mode is set to "UnpluggedOnly" and smart plug details are provided.
+                  2. When tried to run unplugged tests without smart plug details, the script prints error message that smart plug details are mandatory to run unplugged tests.
+                  3. The script exits if all the unplugged scenarios are completed.
+                  4. The script plugs in the device (until it reaches 50%) when the battery drops below 20% during the unplugged tests.
+               #>
+               elseif ($runMode -eq "UnpluggedOnly") {
+
+                  if ($batteryPercentage -lt 20) {
+                     Write-Host "Battery below 20%. Plugging in to charge to 50%..." -ForegroundColor Cyan
+                     SetSmartPlugState $token $SPId 1  # Plug in
+                     while ($batteryPercentage -lt 50) {
+                         Start-Sleep -Seconds 60
+                         $batteryPercentage = Get-BatteryPercentage
+                         Write-Host "Charging... Current battery: $batteryPercentage%" -ForegroundColor Blue
+                     }
+                     Write-Host "Battery reached 50%. Unplugging and resuming tests." -ForegroundColor Green
+                     SetSmartPlugState $token $SPId 0  # Unplug
+                     Start-Sleep -Seconds 10  # Wait for state to stabilize
+                 }
+
+                  if (-not ($token -and $SPId)) {
+                     Write-Error "Smart plug ID is required to run unplugged tests. Exiting."
+                     return
+                  }
                   if ($unpluggedLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
                      $unpluggedLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
                      $devPowStat = "Unplugged"
                      CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   } else {
-                     $pluggedInLast++
-                     $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
-                     $devPowStat = "PluggedIn"
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     Write-Host "All Unplugged scenarios completed. Exiting." -ForegroundColor Yellow
+                     break
                   }
                }
 
-               # Exit loop when all tests are completed
-               if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
-                  Write-Host "breaking from the while loop"
-                  break
+               <#
+               Approach we follow to run only pluggedin tests with or without smart plug details are provided:
+                  1. Run pluggedIn tests for following cases:
+                     a. When the run mode is set to "PluggedInOnly".
+                     b. When the device is charging and run mode is not provided.
+                  2. Above tests run until all the pluggedIn scenarios are completed. 
+                  3. Once all are ompleted, the script exits.
+               #>
+               elseif ($runMode -eq "PluggedInOnly" -or ([string]::IsNullOrEmpty($runMode) -and $chargingState -eq "Charging")) {
+                  if ($pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
+                     $pluggedInLast++
+                     $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
+                     $devPowStat = "PluggedIn"
+                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                  } else {
+                     Write-Host "All PluggedIn scenarios completed. Exiting." -ForegroundColor Yellow
+                     break
+                  } 
+               }
+
+               <#
+               Cases where release tests doesn't run are:
+                  1. .\ReleaseTest.ps1 without connecting to any charger.
+                  2. .\ReleaseTest.ps1 -runMode "UnpluggedOnly" when device is not connect to any smart plug.
+                  3. .\ReleaseTest.ps1 -token "123456" -SPId "7891011" when device is not connect to any charger.
+               #>
+               else {
+                  Write-Error "Invalid run mode specified or necessary parameters missing."
+                  return
                }
             }
          } 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,35 @@ Running the Tests
 Trademarks
 -----
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft trademarks or logos is subject to and must follow [Microsoft’s Trademark & Brand Guidelines](https://www.microsoft.com/en-us/legal/intellectualproperty/trademarks?oneroute=true). Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship. Any use of third-party trademarks or logos are subject to those third-party’s policies.
+
+
+# CameraApp Release Test Automation
+This PowerShell script automates camera app validation across various camera scenarios, video/photo resolutions, and power states (PluggedIn/Unplugged). It uses smart plug automation to simulate real-world battery behavior and toggles AI effects, voice focus, and system settings.
+## Usage
+To run tests using this script, use one of the following commands depending on the desired mode:
+### 1. Both PluggedIn and Unplugged Tests
+Run all scenarios by switching between charging states:
+```powershell
+.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId> -runMode "Both"
+```
+or simply:
+```powershell
+.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId>
+```
+### 2. Only PluggedIn tests
+```powershell
+.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId> -runMode "PluggedInOnly"
+```
+or simply connect charger or smart plug and run
+```powershell
+.\ReleaseTest.ps1 -runMode "PluggedInOnly"
+```
+or simply connect charger or smart plug and run
+```powershell
+.\ReleaseTest.ps1 
+```
+### 3. Only Unplugged tests
+```powershell
+.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId> -runMode "UnpluggedOnly"
+```
+`Important`: Ensure the device battery is above 20% before starting the tests when running in UnpluggedOnly mode or in Both mode (which includes unplugged scenarios).


### PR DESCRIPTION
## Description
Currently we have a wave of tests we run on ReleaseTests.ps1 script which include both pluggedin and unplugged tests back-to-back based on battery percentage.

Once this PR is merged, running release tests for both pluggedin and unplugged tests will happen this way:

.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId> -runMode "Both"
.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId>
For both above commands we need to connect smart plug to the device.
But incase if someone wants to run just pluggedin tests or unplugged tests, there is no feature. This PR brings in that feature.

## How it works is:

We run only pluggedin tests when:
a. connected to smart plug with run mode = pluggedin only:
.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId> -runMode "PluggedInOnly"
b. connected charger:
.\ReleaseTest.ps1 -runMode "PluggedInOnly"
.\ReleaseTest.ps1
We run unplugged tests only when connected to smart plug and run mode = unplugged only
.\ReleaseTest.ps1 -token <your_token> -SPId <your_SPId> -runMode "UnpluggedOnly"
How tested:

## Tested this change for following scenarios:

1. smart plug connected - both pluggedin and unplugged tests: .\ReleaseTest.ps1 -token your_token -SPId your_SPId
2. smart plug connected - only unplugged tests: .\ReleaseTest.ps1 -token your_token -SPId your_SPId-runMode "UnpluggedOnly"
3. smart plug connected - only plugged in tests: .\ReleaseTest.ps1 -runMode "PluggedInOnly". Scripts automatically charges device when the battery percentage is dropped below 20% until it reaches 50% and resumes from where it left of previously.
4. smart plug not connected but charger connected - only plugged in tests: .\ReleaseTest.ps1
All above cases ran as expected.

