### PR TITLE
Created function that can be reused across different PS1 files to eliminate code duplication.

### DIFF
--- a/E2E/CheckInTest/Helper-library.ps1
+++ b/E2E/CheckInTest/Helper-library.ps1
@@ -21,6 +21,7 @@
 .".\Library\ExceptionError.ps1"
 .".\Library\LookUpTable.ps1"
 .".\Library\DeviceDetails.ps1"
+.".\Library\SetupandCompleteTestRun"
 
 .".\CheckInTest\CameraAppTest.ps1"
 .".\CheckInTest\SettingAppTest.ps1"

--- a/E2E/CheckInTest/MemoryUsage.ps1
+++ b/E2E/CheckInTest/MemoryUsage.ps1
@@ -1,6 +1,4 @@
-﻿$photoResolutionList = "2.1 megapixels, 16 by 9 aspect ratio,  1920 by 1080 resolution" , "3.8 megapixels, 16 by 9 aspect ratio,  2592 by 1458 resolution" ,  "12.2 megapixels, 4 by 3 aspect ratio,  4032 by 3024 resolution"
-
-<#
+﻿<#
 DESCRIPTION:
     Captures the Peak Working Set Size (maximum amount of memory used) of the FrameServer process.
 INPUT PARAMETERS:
@@ -47,116 +45,75 @@ function MemoryUsage-Playlist($devPowStat, $token, $SPId)
         #Create Scenario folder
         $scenarioLogFolder = $scenarioName
         CreateScenarioLogsFolder $scenarioLogFolder
-
-        #Toggling All effects on
-        Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to toggle all effects On" -IsOutput
-        ToggleAIEffectsInSettingsApp -AFVal "On" -PLVal "On" -BBVal "On" -BSVal "False" -BPVal "True" `
-                                     -ECVal "On" -ECSVal "False" -ECEVal "True" -VFVal "On" `
-                                     -CF "On" -CFI "False" -CFA "False" -CFW "True"
-                                     
-                     
-        #Open Camera App and set default setting to "Use system settings" 
-        Set-SystemSettingsInCamera
-       
-        #Set video resolution
-        SetvideoResolutionInCameraApp $scenarioName $startTime "1080p, 16 by 9 aspect ratio, 30 fps"
         
-        #Set photo resolution 
-        foreach ($ptoRes in $photoResolutionList)
-        {
-           #Create scenario folder specific to photoresolution for collecting logs
-           Write-Log -Message "Creating folder for capturing logs" -IsOutput
-           $ptoResfolder = $ptoRes.Split(", ") | Select-Object -First 1
-           $ptoResfoldername = $ptoResfolder + "MP"
-           $scenarioLogFolder = "$scenarioName\$ptoResfoldername" 
-           CreateScenarioLogsFolder $scenarioLogFolder
+        # Set up camera effects/settings and start collecting trace
+        Get-InitialSetUp $scenarioName 
+        Start-Sleep -s 2
+        
+        #record video inbetween space presses
+        Write-Log -Message "Start recording a video for $scnds seconds" -IsOutput
+        [System.Windows.Forms.SendKeys]::SendWait(' ');
+        
+        #Sleep for 1 minute before capturing PeakWorkingSetSize
+        Start-Sleep -s 60
+        $i=1
+        $secArray = @(1200, 1200, 1200, 1200, 1200) # Array of sleep durations
+        Foreach($sec in $secArray)
+        {  
+           #Capture Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs 
+           $pekWorkSetSiz = PeakWorkingSetSize
+           Write-Log -Message "Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs: $pekWorkSetSiz" -IsOutput -IsHost
+
+           #Sleep for additional 20 minute before capturing PeakWorkingSetSize
+           start-Sleep -s $sec
+           $pekWorkSetSiz20min = PeakWorkingSetSize
+           Write-Log -Message "PeakWorkingSetSize after $sec secs : $pekWorkSetSiz20min" -IsOutput -IsHost
            
-           $result = SetphotoResolutionInCameraApp $scenarioLogFolder $startTime $ptoRes
-           if($result[-1]  -ne $false)
+           #Compare the Peakworking set and check if the difference is greater than 1000KB between every $sec secs
+           $difference = $pekWorkSetSiz20min - $pekWorkSetSiz
+           Write-Log -Message "Difference between PeakWorkingSet after every $sec secs: $difference" -IsOutput
+           #Checking if the value is not negative and greater than 1000KB
+           if(($difference -le 0) -and ($difference -gt 1000))
            {
-              #Checks if frame server is stopped
-              Write-Log -Message "Entering CheckServiceState function" -IsOutput
-              CheckServiceState 'Windows Camera Frame Server'
-                            
-              #Strating to collect Traces
-              Write-Log -Message "Entering StartTrace function" -IsOutput
-              StartTrace $scenarioLogFolder
-              
-              #Start video recording and close the camera app once finished recording 
-              #Open Camera App
-              Write-Log -Message "Open camera App" -IsOutput
-              $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
-              Start-Sleep -s 1
-                                                                        
-              #Switch to video mode if not in video mode
-              SwitchModeInCameraApp $ui "Switch to video mode" "Take video" 
-              Start-Sleep -s 2
-              
-              #record video inbetween space presses
-              Write-Log -Message "Start recording a video for $scnds seconds" -IsOutput
-              [System.Windows.Forms.SendKeys]::SendWait(' ');
-              
-              #Sleep for 1 minute before capturing PeakWorkingSetSize
-              Start-Sleep -s 60
-              $i=1
-              Foreach($sec in 1200, 1200, 1200, 1200, 1200)
-              {  
-                 #Capture Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs 
-                 $pekWorkSetSiz = PeakWorkingSetSize
-                 Write-Log -Message "Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs: $pekWorkSetSiz" -IsOutput -IsHost
-
-                 #Sleep for additional 20 minute before capturing PeakWorkingSetSize
-                 start-Sleep -s $sec
-                 $pekWorkSetSiz20min = PeakWorkingSetSize
-                 Write-Log -Message "PeakWorkingSetSize after $sec secs : $pekWorkSetSiz20min" -IsOutput -IsHost
-                 
-                 #Compare the Peakworking set and check if the difference is greater than 1000KB between every $sec secs
-                 $difference = $pekWorkSetSiz20min - $pekWorkSetSiz
-                 Write-Log -Message "Difference between PeakWorkingSet after every $sec secs: $difference" -IsOutput
-                 if(($difference -gt 0) -and ($difference -gt 1000))
-                 {
-                    $greaterThan1000KB = $True
-                    write-host "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -BackgroundColor Red
-                    write-Output "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz"  >>  $pathLogsFolder\ConsoleResults.txt
-                 } 
-                 else
-                 {
-                    Write-Log -Message "PeakworkingSet difference is not greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -IsHost
-                 }
-                 $i++
-              
-              }
-              Start-Sleep -s 2
-              
-              #Close Camera App
-              CloseApp 'WindowsCamera'
-              
-                                        
-              #Checks if frame server is stopped
-              Write-Log -Message "Entering CheckServiceState function" -IsOutput
-              CheckServiceState 'Windows Camera Frame Server' 
-              
-              #Stop the Trace
-              Write-Log -Message "Entering StopTrace function" -IsOutput
-              StopTrace $scenarioLogFolder
-              
-              #Fail the test if Peakworkingset size difference is greater than 1000KB
-              if($greaterThan1000KB -eq $True)
-              {
-                 TestOutputMessage $scenarioLogFolder "Fail" $startTime "PeakworkingSet difference is greater than 1000KB"
-              }
-              else
-              {
-                 TestOutputMessage $scenarioLogFolder "Pass" $startTime "PeakworkingSet difference is not greater than 1000KB"
-              } 
-                           
-                                                         
-              #For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
-              SetSmartPlugState $token $SPId 1    
-
-           }             
- 
+              # Peakworkingset greater than 1000KB is just an indication that there could be memory leak. Next step would be to enable appvifier and collect dump manually.
+              $greaterThan1000KB = $True
+              write-host "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -BackgroundColor Red
+              write-Output "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz"  >>  $pathLogsFolder\ConsoleResults.txt
+           } 
+           else
+           {
+              Write-Log -Message "PeakworkingSet difference is not greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -IsHost -IsOutput
+           }
+           $i++
+        
         }
+        Start-Sleep -s 2
+        
+        #Close Camera App
+        CloseApp 'WindowsCamera'
+        
+                                  
+        #Checks if frame server is stopped
+        Write-Log -Message "Entering CheckServiceState function" -IsOutput
+        CheckServiceState 'Windows Camera Frame Server' 
+        
+        #Stop the Trace
+        Write-Log -Message "Entering StopTrace function" -IsOutput
+        StopTrace $scenarioLogFolder
+        
+        #Fail the test if Peakworkingset size difference is greater than 1000KB
+        if($greaterThan1000KB -eq $True)
+        {
+           TestOutputMessage $scenarioLogFolder "Fail" $startTime "PeakworkingSet difference is greater than 1000KB"
+        }
+        else
+        {
+           TestOutputMessage $scenarioLogFolder "Pass" $startTime "PeakworkingSet difference is not greater than 1000KB"
+        } 
+                     
+                                                   
+        #For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
+        SetSmartPlugState $token $SPId 1    
     }
     catch
     {   

--- a/E2E/CheckInTest/MemoryUsage.ps1
+++ b/E2E/CheckInTest/MemoryUsage.ps1
@@ -42,7 +42,7 @@ function MemoryUsage-Playlist($devPowStat, $token, $SPId)
          
     try
 	{  
-        #Create Scenario folder
+        # Create Scenario folder
         $scenarioLogFolder = $scenarioName
         CreateScenarioLogsFolder $scenarioLogFolder
         
@@ -50,32 +50,32 @@ function MemoryUsage-Playlist($devPowStat, $token, $SPId)
         Get-InitialSetUp $scenarioName 
         Start-Sleep -s 2
         
-        #record video inbetween space presses
+        # Record video inbetween space presses
         Write-Log -Message "Start recording a video for $scnds seconds" -IsOutput
         [System.Windows.Forms.SendKeys]::SendWait(' ');
         
-        #Sleep for 1 minute before capturing PeakWorkingSetSize
+        # Sleep for 1 minute before capturing PeakWorkingSetSize
         Start-Sleep -s 60
         $i=1
         $secArray = @(1200, 1200, 1200, 1200, 1200) # Array of sleep durations
         Foreach($sec in $secArray)
         {  
-           #Capture Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs 
+           # Capture Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs 
            $pekWorkSetSiz = PeakWorkingSetSize
            Write-Log -Message "Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs: $pekWorkSetSiz" -IsOutput -IsHost
 
-           #Sleep for additional 20 minute before capturing PeakWorkingSetSize
+           # Sleep for additional 20 minute before capturing PeakWorkingSetSize
            start-Sleep -s $sec
            $pekWorkSetSiz20min = PeakWorkingSetSize
            Write-Log -Message "PeakWorkingSetSize after $sec secs : $pekWorkSetSiz20min" -IsOutput -IsHost
            
-           #Compare the Peakworking set and check if the difference is greater than 1000KB between every $sec secs
+           # Compare the Peakworking set and check if the difference is greater than 1000KB between every $sec secs
            $difference = $pekWorkSetSiz20min - $pekWorkSetSiz
            Write-Log -Message "Difference between PeakWorkingSet after every $sec secs: $difference" -IsOutput
-           #Checking if the value is not negative and greater than 1000KB
+           # Checking if the value is not negative and greater than 1000KB
            if(($difference -le 0) -and ($difference -gt 1000))
            {
-<<<<<<< HEAD
+
               # Peakworkingset greater than 1000KB is just an indication that there could be memory leak. Next step would be to enable appvifier and collect dump manually.
               $greaterThan1000KB = $True
               write-host "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -BackgroundColor Red
@@ -86,110 +86,22 @@ function MemoryUsage-Playlist($devPowStat, $token, $SPId)
               Write-Log -Message "PeakworkingSet difference is not greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -IsHost -IsOutput
            }
            $i++
-        
-=======
-              #Checks if frame server is stopped
-              Write-Log -Message "Entering CheckServiceState function" -IsOutput
-              CheckServiceState 'Windows Camera Frame Server'
-                            
-              #Strating to collect Traces
-              Write-Log -Message "Entering StartTrace function" -IsOutput
-              StartTrace $scenarioLogFolder
-              
-              #Start video recording and close the camera app once finished recording 
-              #Open Camera App
-              Write-Log -Message "Open camera App" -IsOutput
-              $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
-              Start-Sleep -s 1
-                                                                        
-              #Switch to video mode if not in video mode
-              SwitchModeInCameraApp $ui "Switch to video mode" "Take video" 
-              Start-Sleep -s 2
-              
-              #record video inbetween space presses
-              Write-Log -Message "Start recording a video for $scnds seconds" -IsOutput
-              [System.Windows.Forms.SendKeys]::SendWait(' ');
-              
-              #Sleep for 1 minute before capturing PeakWorkingSetSize
-              Start-Sleep -s 60
-              $i=1
-              $secArray = @(1200, 1200, 1200, 1200, 1200) # Array of sleep durations
-              Foreach($sec in $secArray)
-              {  
-                 #Capture Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs 
-                 $pekWorkSetSiz = PeakWorkingSetSize
-                 Write-Log -Message "Initial PeakWorkingSetSize before starting sleep again for adiitional $sec secs: $pekWorkSetSiz" -IsOutput -IsHost
-
-                 #Sleep for additional 20 minute before capturing PeakWorkingSetSize
-                 start-Sleep -s $sec
-                 $pekWorkSetSiz20min = PeakWorkingSetSize
-                 Write-Log -Message "PeakWorkingSetSize after $sec secs : $pekWorkSetSiz20min" -IsOutput -IsHost
-                 
-                 #Compare the Peakworking set and check if the difference is greater than 1000KB between every $sec secs
-                 $difference = $pekWorkSetSiz20min - $pekWorkSetSiz
-                 Write-Log -Message "Difference between PeakWorkingSet after every $sec secs: $difference" -IsOutput
-                 #Checking if the value is not negative and greater than 1000KB
-                 if(($difference -le 0) -and ($difference -gt 1000))
-                 {
-                    # Peakworkingset greater than 1000KB is just an indication that there could be memory leak. Next step would be to enable appvifier and collect dump manually.
-                    $greaterThan1000KB = $True
-                    write-host "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -BackgroundColor Red
-                    write-Output "PeakworkingSet difference is greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz"  >>  $pathLogsFolder\ConsoleResults.txt
-                 } 
-                 else
-                 {
-                    Write-Log -Message "PeakworkingSet difference is not greater than 1000KB for run $i. Difference after every $sec is: $difference = $pekWorkSetSiz20min - $pekWorkSetSiz" -IsHost -IsOutput
-                 }
-                 $i++
-              
-              }
-              Start-Sleep -s 2
-              
-              #Close Camera App
-              CloseApp 'WindowsCamera'
-              
-                                        
-              #Checks if frame server is stopped
-              Write-Log -Message "Entering CheckServiceState function" -IsOutput
-              CheckServiceState 'Windows Camera Frame Server' 
-              
-              #Stop the Trace
-              Write-Log -Message "Entering StopTrace function" -IsOutput
-              StopTrace $scenarioLogFolder
-              
-              #Fail the test if Peakworkingset size difference is greater than 1000KB
-              if($greaterThan1000KB -eq $True)
-              {
-                 TestOutputMessage $scenarioLogFolder "Fail" $startTime "PeakworkingSet difference is greater than 1000KB"
-              }
-              else
-              {
-                 TestOutputMessage $scenarioLogFolder "Pass" $startTime "PeakworkingSet difference is not greater than 1000KB"
-              } 
-                           
-                                                         
-              #For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
-              SetSmartPlugState $token $SPId 1    
-
-           }             
- 
->>>>>>> main
         }
         Start-Sleep -s 2
         
-        #Close Camera App
+        # Close Camera App
         CloseApp 'WindowsCamera'
         
                                   
-        #Checks if frame server is stopped
+        # Checks if frame server is stopped
         Write-Log -Message "Entering CheckServiceState function" -IsOutput
         CheckServiceState 'Windows Camera Frame Server' 
         
-        #Stop the Trace
+        # Stop the Trace
         Write-Log -Message "Entering StopTrace function" -IsOutput
         StopTrace $scenarioLogFolder
         
-        #Fail the test if Peakworkingset size difference is greater than 1000KB
+        # Fail the test if Peakworkingset size difference is greater than 1000KB
         if($greaterThan1000KB -eq $True)
         {
            TestOutputMessage $scenarioLogFolder "Fail" $startTime "PeakworkingSet difference is greater than 1000KB"
@@ -198,9 +110,7 @@ function MemoryUsage-Playlist($devPowStat, $token, $SPId)
         {
            TestOutputMessage $scenarioLogFolder "Pass" $startTime "PeakworkingSet difference is not greater than 1000KB"
         } 
-                     
-                                                   
-        #For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
+        # For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
         SetSmartPlugState $token $SPId 1    
     }
     catch

--- a/E2E/CheckInTest/Min-Max-CameraApp.ps1
+++ b/E2E/CheckInTest/Min-Max-CameraApp.ps1
@@ -32,28 +32,8 @@ function Min-Max-CameraApp($devPowStat, $token, $SPId)
         Write-Log -Message "Creating folder for capturing logs" -IsOutput
         CreateScenarioLogsFolder $scenarioName
                 
-        # Starting to collect Traces for generic error
-        Write-Log -Message "Entering StartTrace" -IsOutput
-        StartTrace $scenarioName
-
-        # Open Camera App and set default setting to "Use system settings" 
-        Set-SystemSettingsInCamera
-
-        # Toggling All effects on
-        Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to toggle all effects On" -IsOutput
-        ToggleAIEffectsInSettingsApp -AFVal "On" -PLVal "On" -BBVal "On" -BSVal "False" -BPVal "True" `
-                                     -ECVal "On" -ECSVal "False" -ECEVal "True" -VFVal "On" `
-                                     -CF "On" -CFI "False" -CFA "False" -CFW "True"
-       
-        Start-Sleep -s 2
-
-        # Open Camera App
-        Write-Log -Message "Open camera App" -IsOutput
-        $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
-        Start-Sleep -s 1
-        
-        #Switch to video mode
-        SwitchModeInCameraApp $ui "Switch to video mode" "Take video" 
+        # Set up camera effects/settings and start collecting trace
+        Get-InitialSetUp $scenarioName 
         Start-Sleep -s 2
 
         $shell = New-Object -ComObject "Shell.Application"
@@ -142,3 +122,15 @@ function Min-Max-CameraApp($devPowStat, $token, $SPId)
        Error-Exception -snarioName $scenarioName -strttme $startTime -rslts $Results -logFile $logFile -token $token -SPID $SPID
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+

--- a/E2E/CheckInTest/RevisitCameraSettingPage.ps1
+++ b/E2E/CheckInTest/RevisitCameraSettingPage.ps1
@@ -38,6 +38,7 @@ function RevisitCameraSetting($times)
       else
       {
           FindAndClick $ui Button "Connected enabled camera $Global:validatedCameraFriendlyName"
+          start-sleep -Seconds 2
       }  
        $i++
    }
@@ -148,34 +149,8 @@ function RevisitCameraSettingPage($devPowStat, $token, $SPId)
         # Close settings app
         CloseApp 'systemsettings'
 
-        # Checks if frame server is stopped
-        Write-Log -Message "Entering CheckServiceState function" -IsOutput
-        CheckServiceState 'Windows Camera Frame Server'
-
-        # Stop the Trace
-        Write-Log -Message "Entering StopTrace function" -IsOutput
-        StopTrace $scenarioName
-                                              
-        # Verify and validate if proper logs are generated or not.   
-        $wsev2PolicyState = CheckWSEV2Policy
-        if($wsev2PolicyState -eq $false)
-        {  
-           # ScenarioID 81968 is based on v1 effects.
-           Write-Log -Message "Entering Verifylogs function" -IsOutput
-           Verifylogs $scenarioName "81968" $startTime
-        }
-        else
-        { 
-           # ScenarioID 737312 is based on v1+v2 effects.   
-           Write-Log -Message "Entering Verifylogs function" -IsOutput
-           Verifylogs $scenarioName "2834432" $startTime #(Need to change the scenario ID, not sure if this is correct)
-        }
-
-        #collect data for Reporting
-        Reporting $Results "$pathLogsFolder\Report.txt"
-
-        #For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
-        SetSmartPlugState $token $SPId 1
+        # Verify logs and capture results.
+        Complete-TestRun $scenarioName $startTime $token $SPId
        
     }
     catch
@@ -183,3 +158,5 @@ function RevisitCameraSettingPage($devPowStat, $token, $SPId)
        Error-Exception -snarioName $scenarioName -strttme $startTime -rslts $Results -logFile $logFile -token $token -SPID $SPID
     }
 }
+
+

--- a/E2E/CheckInTest/SettingAppHibernation.ps1
+++ b/E2E/CheckInTest/SettingAppHibernation.ps1
@@ -67,38 +67,12 @@ function SettingApp-Hibernation($devPowStat, $token, $SPId)
 
         # Close settings app
         CloseApp 'systemsettings'
-
-        # Checks if frame server is stopped
-        Write-Log -Message "Entering CheckServiceState function" -IsOutput
-        CheckServiceState 'Windows Camera Frame Server'
-
-        # Stop the Trace
-        Write-Log -Message "Entering StopTrace function" -IsOutput
-        StopTrace $scenarioName
-                                              
-        $wsev2PolicyState = CheckWSEV2Policy
-        if($wsev2PolicyState -eq $false)
-        {  
-           # ScenarioID 81968 is based on v1 effects.   
-           Write-Log -Message "Entering Verifylogs function" -IsOutput
-           Verifylogs $scenarioName "81968" $startTime
-        }
-        else
-        { 
-           # ScenarioID 737312 is based on v1+v2 effects.   
-           Write-Log -Message "Entering Verifylogs function" -IsOutput
-           Verifylogs $scenarioName "2834432" $startTime #(Need to change the scenario ID, not sure if this is correct)
-        }
-
-
-        #Verify logs for number of hiberantion cycle
-        VerifyLogs-Hibernation $scenarioName
-
-        #collect data for Reporting
-        Reporting $Results "$pathLogsFolder\Report.txt"
-
-        #For our Sanity, we make sure that we exit the test in netural state,which is pluggedin
-        SetSmartPlugState $token $SPId 1
+        
+       # Verify logs and capture results.
+       Complete-TestRun $scenarioName $startTime $token $SPId
+               
+       #Verify logs for number of hibernation cycles
+       VerifyLogs-Hibernation $scenarioName
        
     }
     catch

--- a/E2E/CheckInTest/ToggleAIEffectsMultipleTimes.ps1
+++ b/E2E/CheckInTest/ToggleAIEffectsMultipleTimes.ps1
@@ -57,12 +57,16 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
         Write-Log -Message "Creating folder for capturing logs" -IsOutput
         CreateScenarioLogsFolder $scenarioName
 
+        # Open Camera App and set default setting to "Use system settings" 
+        Set-SystemSettingsInCamera
+
+        # Checks if frame server is stopped
+        Write-Log -Message "Entering CheckServiceState function" -IsOutput
+        CheckServiceState 'Windows Camera Frame Server'
+                
         # Starting to collect Traces for generic error
         Write-Log -Message "Entering StartTrace" -IsOutput
         StartTrace $scenarioName
-
-       # Open Camera App and set default setting to "Use system settings" 
-       Set-SystemSettingsInCamera
 
         # Open settings app and obtain UI automation from it
         $ui = OpenApp 'ms-settings:' 'Settings'
@@ -72,6 +76,7 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
         Write-Log -Message "Navigate to camera effects setting page" -IsOutput
         FindCameraEffectsPage $ui
         Start-Sleep -m 500 
+
                
         Write-Log -Message "Toggle camera effects in setting Page" -IsOutput
         OnandOffAiEffects $ui ToggleSwitch "Automatic framing" "2"
@@ -107,6 +112,7 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
         OnandOffAiEffects $ui ToggleSwitch "Automatic framing" "2"
         OnandOffAiEffects $ui ToggleSwitch "Eye contact" "2"
         OnandOffAiEffects $ui ToggleSwitch "Background effects" "2"
+        
         $wsev2PolicyState = CheckWSEV2Policy
         if($wsev2PolicyState -eq $true)
         {
@@ -236,3 +242,15 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
        Error-Exception -snarioName $scenarioName -strttme $startTime -rslts $Results -logFile $logFile -token $token -SPID $SPID
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+

--- a/E2E/Library/SetupandCompleteTestRun.ps1
+++ b/E2E/Library/SetupandCompleteTestRun.ps1
@@ -1,4 +1,15 @@
-﻿function Get-InitialSetUp($scenarioName)
+﻿<#
+DESCRIPTION:
+    This function performs an initial setup for a camera scenario test. It configures system settings, 
+    enables AI effects, sets the highest available photo and video resolutions, verifies the frame 
+    server state, starts trace collection, opens the Camera App, and switches to video mode to prepare 
+    for further tests.
+INPUT PARAMETERS:
+    - scenarioName [string] :- The name of the test scenario being executed.
+RETURN TYPE:
+    - void
+#>
+function Get-InitialSetUp($scenarioName)
 {
    Write-Log -Message "Entering Get-InitialSetUp function" -IsOutput
     
@@ -33,7 +44,20 @@
    # Switch to video mode as photo mode doesn't support MEP
    SwitchModeInCameraApp $ui "Switch to video mode" "Take video"  
 }
-
+<#
+DESCRIPTION:
+    This function completes the camera test run by ensuring the system returns to a neutral state, 
+    stopping trace collection, verifying logs for correctness, and generating a report. It also checks 
+    the frame server state, adjusts the scenario ID based on policy, and controls the smart plug state 
+    to ensure the device is plugged in at the end of the test.
+INPUT PARAMETERS:
+    - scenarioName [string] :- The name of the test scenario.
+    - startTime [string] :- The start time of the test run, used for reporting purposes.
+    - token [string] :- Authentication token required to control the smart plug.
+    - SPId [string] :- Smart plug ID used to control device power states.
+RETURN TYPE:
+    - void
+#>
 Function Complete-TestRun($scenarioName, $startTime, $token, $SPId)
 {
     

--- a/E2E/Library/SetupandCompleteTestRun.ps1
+++ b/E2E/Library/SetupandCompleteTestRun.ps1
@@ -1,0 +1,73 @@
+﻿function Get-InitialSetUp($scenarioName)
+{
+   Write-Log -Message "Entering Get-InitialSetUp function" -IsOutput
+    
+   # Open Camera App and set default setting to "Use system settings" 
+   Set-SystemSettingsInCamera
+   
+   # Toggling All effects on
+   Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to toggle all effects On" -IsOutput
+   ToggleAIEffectsInSettingsApp -AFVal "On" -PLVal "On" -BBVal "On" -BSVal "False" -BPVal "True" `
+                                -ECVal "On" -ECSVal "False" -ECEVal "True" -VFVal "On" `
+                                -CF "On" -CFI "False" -CFA "False" -CFW "True"
+
+   # Set photo resolution
+   $photoResName = SetHighestPhotoResolutionInCameraApp 
+   $phoResNme = RetrieveValue $photoResName[-1]
+   
+   # Set video resolution
+   $videoResName = SetHighestVideoResolutionInCameraApp
+   $vdoResNme = RetrieveValue $videoResName[-1]
+           
+   # Checks if frame server is stopped
+   Write-Log -Message "Entering CheckServiceState function" -IsOutput
+   CheckServiceState 'Windows Camera Frame Server'
+                 
+   # Starting to collect Traces
+   Write-Log -Message "Entering StartTrace function" -IsOutput
+   StartTrace $scenarioName
+   
+   # Open Camera App
+   $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
+   
+   # Switch to video mode as photo mode doesn't support MEP
+   SwitchModeInCameraApp $ui "Switch to video mode" "Take video"  
+}
+
+Function Complete-TestRun($scenarioName, $startTime, $token, $SPId)
+{
+    
+   Write-Log -Message "Entering Complete-TestRun function" -IsOutput
+   
+   # Checks if frame server is stopped
+   Write-Log -Message "Entering CheckServiceState function" -IsOutput
+   CheckServiceState 'Windows Camera Frame Server'
+   
+   # Stop the Trace
+   Write-Log -Message "Entering StopTrace function" -IsOutput
+   StopTrace $scenarioName
+                                            
+   # Verify and validate if proper logs are generated or not.   
+   $wsev2PolicyState = CheckWSEV2Policy
+   
+   # Set the ScenarioID based on the policy state
+   if ($wsev2PolicyState -eq $false) {
+       $scenarioID = "81968"  # Based on v1 effects
+   } else {
+       $scenarioID = "2834432"  # Based on v1+v2 effects, verify if this is correct
+   }
+   
+   # Log the entry to Verifylogs function
+   Write-Log -Message "Entering Verifylogs function with ScenarioID $scenarioID" -IsOutput
+   
+   # Call Verifylogs function
+   Verifylogs $scenarioName $scenarioID $startTime
+   
+  
+   #Collect data for Reporting
+   Reporting $Results "$pathLogsFolder\Report.txt"
+
+   #For our Sanity, we make sure that we exit the test in neutral state, which is plugged in
+   SetSmartPlugState $token $SPId 1
+}
+


### PR DESCRIPTION
## What changed?
Created Get-InitialSetUp and Complete-TestRun function that can be reused across different PS1 files to eliminate duplication.
## Why changed?
To remove code redundancy. The same or similar lines of code are repeated across multiple PS1 files.
## How did you test the change?
Tested and already merged in our repo.
## Related Issues (if any):

