### PR TITLE
Akhilmehnot/fetch dynamic resolution

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -25,6 +25,8 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
    {  
        $startTime = Get-Date
        $VFdetails= "VF-$VF"
+	   $vdoRes= RetrieveValue($vdoRes)
+	   $ptoRes= RetrieveValue($ptoRes)       
        $scenarioLogFolder = "CameraAppTest\$camsnario\$vdoRes\$ptoRes\$devPowStat\$VFdetails\$toggleEachAiEffect"
        Write-Log -Message "`nStarting Test for $scenarioLogFolder`n" -IsOutput
        Write-Log -Message "Creating the log folder" -IsOutput       
@@ -64,7 +66,6 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
           
           #Retrieve video resolution from hash table
           Write-Log -Message "Retrieve $vdoRes value from hash table" -IsOutput
-          $vdoRes = RetrieveValue $vdoRes
           
           #skip the test if video resolution is not available. 
           $result = SetvideoResolutionInCameraApp $scenarioLogFolder $startTime $vdoRes
@@ -79,7 +80,6 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
           
           #Retrieve photo resolution from hash table
           Write-Log -Message "Retrieve $ptoRes value from hash table" -IsOutput
-          $ptoRes = RetrieveValue $ptoRes
           #skip the test if photo resolution is not available. 
           $result = SetphotoResolutionInCameraApp $scenarioLogFolder $startTime $ptoRes
           if($result[-1]  -eq $false)

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -19,8 +19,8 @@ function GetDeviceDetails()
    $deviceData = @{}
 
    $deviceData.CameraScenario   = @("Recording" , "Previewing") #We run for Recording only if there are many scenarios to be covered
-   $deviceData.VideoResolutions = GetVideoResList -videoResolutions @('1440p', '1080p', '720p', '480p', '360p', '1440p1', '1080p1', '960p', '640p', '540p')
-   $deviceData.PhotoResolutions = GetPhotoResList -photoResolutions @('12.2MP', '5.0MP', '2.1MP', '0.9MP', '0.3MP', '0.2MP')
+   $deviceData.VideoResolutions = GetVideoResList
+   $deviceData.PhotoResolutions = GetPhotoResList
    $deviceData.PowerStates      = @("Pluggedin", "Unplugged")
    $voiceFocusExists = CheckVoiceFocusPolicy 
    if($voiceFocusExists -eq $false)
@@ -73,13 +73,10 @@ DESCRIPTION:
     This function retrieves the list of supported video resolutions from the Camera app settings.
     It opens the Camera app, switches to video mode, and checks the available video quality options.
 
-INPUT PARAMETERS:
-    - videoResolutions [array]: An array of video resolution names to check for support.
-
 RETURN TYPE:
     - Array: List of supported video resolutions.
 #>
-Function GetVideoResList($videoResolutions)
+Function GetVideoResList()
 {
      #Open Camera App
      $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
@@ -89,39 +86,14 @@ Function GetVideoResList($videoResolutions)
      $return = CheckIfElementExists $ui ToggleButton "Take video" 
      if ($return -eq $null){
         FindAndClick $ui Button "Switch to video mode" 
-        Start-Sleep -s 2  
-     }
-     else
-     {
-       #It should already be in video mode
-       Start-Sleep -s 1
      }
      #Get video quality 
-     FindAndClick $ui Button "Open Settings Menu"
-     Start-Sleep -s 1
-    
+     FindAndClick $ui Button "Open Settings Menu"    
      #Find video settings and click
-     FindAndClickList -uiEle $ui -clsNme Microsoft.UI.Xaml.Controls.Expander -proptyNmeLst @('Videos settings','Video settings')
-     Start-Sleep -s 1
-     
+     FindAndClickList -uiEle $ui -clsNme Microsoft.UI.Xaml.Controls.Expander -proptyNmeLst @('Videos settings','Video settings')     
      FindAndClick $ui ComboBox "Video quality"
-     Start-Sleep -s 1
-     $vdoResList = @()
-     foreach($vdoRes in  $videoResolutions)
-     {
-        $vdoResDetails = RetrieveValue $vdoRes
-        
-        #Get the supported video resolution
-        $return = CheckIfElementExists $ui ComboBoxItem $vdoResDetails
-        if ($return -ne $null)
-        {
-           $vdoResList += $vdoRes
-        }
-        else
-        {
-            continue;
-        }
-     }
+     $vdoRes = FindAllElementsNameWithClassName $ui ComboBoxItem
+	 $vdoResList = $vdoRes | Where-Object { $_ -match 'aspect' }
      Stop-Process -Name 'WindowsCamera'
      start-sleep -s 1
      return $vdoResList
@@ -132,44 +104,23 @@ DESCRIPTION:
     This function retrieves the list of supported photo resolutions from the Camera app settings.
     It opens the Camera app and checks the available photo quality options.
 
-INPUT PARAMETERS:
-    - photoResolutions [array]: An array of photo resolution names to check for support.
-
 RETURN TYPE:
     - Array: List of supported photo resolutions.
 #>
-Function GetPhotoResList($photoResolutions)
+Function GetPhotoResList()
 {
    #Open Camera App
    $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
    Start-Sleep -s 1
 
    #Get photo quality
-   FindAndClick $ui Button "Open Settings Menu"
-   Start-Sleep -s 1 
-   
+   FindAndClick $ui Button "Open Settings Menu" 
    #Find Photo settings and click
    FindAndClickList -uiEle $ui -clsNme Microsoft.UI.Xaml.Controls.Expander -proptyNmeLst @('Photos settings','Photo settings')
-   Start-Sleep -s 1
-
    FindAndClick $ui ComboBox "Photo quality"
    Start-Sleep -s 1
-   $ptoResList = @()
-   foreach($ptoRes in  $photoResolutions)
-   {
-      $ptoResDetails = RetrieveValue $ptoRes
-      
-      #Get the supported video resolution
-      $return = CheckIfElementExists $ui ComboBoxItem $ptoResDetails
-      if ($return -ne $null)
-      {
-         $ptoResList += $ptoRes
-      }
-      else
-      {
-          continue;
-      }
-   }
+   $ptoRes = FindAllElementsNameWithClassName $ui ComboBoxItem
+   $ptoResList = $ptoRes | Where-Object { $_ -match 'aspect' }
    Stop-Process -Name 'WindowsCamera'
    start-sleep -s 1
    return $ptoResList

--- a/E2E/Library/FindClickableElement.ps1
+++ b/E2E/Library/FindClickableElement.ps1
@@ -23,7 +23,7 @@ function CheckIfElementExists($uiEle, $clsNme, $proptyNme, $timeoutSeconds = 2) 
         Start-Sleep -Milliseconds 100  # Check every 100ms
     }
     if ($elemt -eq $null){
-        Write-Error " $proptyNme not found " -ErrorAction Stop  
+        Write-Error "$proptyNme not found " -ErrorAction Continue
     }        
     return $elemt
 }

--- a/E2E/Library/FindClickableElement.ps1
+++ b/E2E/Library/FindClickableElement.ps1
@@ -157,7 +157,41 @@ function FindFirstElementsNameWithClassName($uiEle, $clsNme, $timeoutSeconds = 2
     }
     return $elemt.GetCurrentPropertyValue([Windows.Automation.AutomationElement]::NameProperty)     
 }
-    
+
+<#
+DESCRIPTION:
+    This function retrieves the name of the all UI element found with the specified class name.
+    Its returning duplicate values, handled by Sort-Object -Unique
+INPUT PARAMETERS:
+    - uiEle [object] :- The root UI element to search within.
+    - clsNme [string] :- The class name of the UI element to search for.
+RETURN TYPE:
+    - [string] :- Returns the name of the all matching UI element.
+#>
+function FindAllElementsNameWithClassName($uiEle, $clsNme, $timeoutSeconds = 2)
+{
+    if ($uiEle -eq $null)
+    {
+      Write-Error " UI Element for $proptyNme is Null" -ErrorAction Stop
+    }
+
+    $classNameCondition = New-Object Windows.Automation.PropertyCondition([Windows.Automation.AutomationElement]::ClassNameProperty, $clsNme)
+
+    $endTime = [DateTime]::Now.AddSeconds($timeoutSeconds)
+    $elemt = $null    
+
+    while ([DateTime]::Now -lt $endTime -and $elemt -eq $null) {
+        $elemt = $uiEle.FindAll([Windows.Automation.TreeScope]::Descendants, $classNameCondition)
+        Start-Sleep -Milliseconds 100  # Check every 100ms
+    }
+
+    if ($elemt -eq $null) {
+        Write-Error "$clsNme not found" -ErrorAction Stop  
+    }
+	$uniqueElemt = $elemt | ForEach-Object { $_.GetCurrentPropertyValue([Windows.Automation.AutomationElement]::NameProperty) } | Sort-Object -Unique
+    return $uniqueElemt    
+}
+
 <#
 DESCRIPTION:
     This function finds and clicks on a UI element based on class name, property name, or Automation ID. It supports multiple interaction patterns like Invoke, Select, Toggle, and Expand.

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -21,14 +21,14 @@ foreach($camsnario in $deviceData["CameraScenario"])
    {  
       $initialSetupDone = "true" 
       $startTime = Get-Date 
-      $scenarioName = "CameraAppTest\$camsnario\$vdoRes" 
       #Retrieve video resolution from hash table
-      $vdoResDetails = RetrieveValue $vdoRes
+	   $vdoResDetails= RetrieveValue($vdoRes)
+      $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
 
-      Write-Log -Message "Setting up video Res to $vdoResDetails" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+      Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
       
       #skip the test if video resolution is not available. 
-      $result = SetvideoResolutionInCameraApp $scenarioName $startTime $vdoResDetails
+      $result = SetvideoResolutionInCameraApp $scenarioName $startTime $vdoRes
       if($result[-1]  -eq $false)
       {
          write-Error "Expected video Res is not found: $vdoRes"
@@ -38,14 +38,14 @@ foreach($camsnario in $deviceData["CameraScenario"])
       # Loop through photo resolutions  
       foreach ($ptoRes in  $deviceData["PhotoResolutions"])
       {   
-         $scenarioName = "CameraAppTest\$camsnario\$vdoRes\$ptoRes" 
-         #Retrieve photo resolution from hash table
-         $ptoResDetails = RetrieveValue $ptoRes
+         #Retrieve photo resolution from hash table 
+         $ptoResDetails= RetrieveValue($ptoRes)       
+         $scenarioName = "CameraAppTest\$camsnario\$vdoResPath\$ptoResDetails" 
 
-         Write-Log -Message "Setting up Photo Res to $ptoResDetails" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+         Write-Log -Message "Setting up Photo Res to $ptoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
 
          #skip the test if photo resolution is not available. 
-         $result = SetphotoResolutionInCameraApp $scenarioName $startTime $ptoResDetails
+         $result = SetphotoResolutionInCameraApp $scenarioName $startTime $ptoRes
          if($result[-1]  -eq $false)
          {
             write-Error "Expected Photo Res is not found: $ptoRes"


### PR DESCRIPTION
## What changed?
Updated the Write-Error to continue while checking for element existence
## Why changed?
The FindCameraEffectsPage method, checks for camera across device, which fails and check with different option again for camera existence. Write-Error with stop, was causing the issue
## How did you test the change?
Tested with releaseTest and checkinTest
## Related Issues (if any):

