### PR TITLE
Update Write-Error action to continue, as we expect function to continue, if element doesn't exist, to support multiple devices

### DIFF
--- a/E2E/Library/FindClickableElement.ps1
+++ b/E2E/Library/FindClickableElement.ps1
@@ -23,7 +23,7 @@ function CheckIfElementExists($uiEle, $clsNme, $proptyNme, $timeoutSeconds = 2) 
         Start-Sleep -Milliseconds 100  # Check every 100ms
     }
     if ($elemt -eq $null){
-        Write-Error " $proptyNme not found " -ErrorAction Stop  
+        Write-Error "$proptyNme not found " -ErrorAction Continue  
     }        
     return $elemt
 }


### PR DESCRIPTION
## What changed?

Updated the Write-Error to continue while checking for element existence

## Why changed?

The FindCameraEffectsPage method, checks for camera across device, which fails and check with different option again for camera existence. Write-Error with stop, was causing the issue

## How did you test the change?
Tested with releaseTest and checkinTest

## Related Issues (if any):

