### PR TITLE
Initial version of CameraReliabilityTest

### DIFF
--- a/E2E/CameraReliabilityTest.ps1
+++ b/E2E/CameraReliabilityTest.ps1
@@ -1,0 +1,133 @@
+param (
+   [string] $token = $null,
+   [string] $SPId = $null,
+   [string] $targetMepCameraVer = $null,
+   [string] $targetMepAudioVer = $null,
+   [string] $targetPerceptionCoreVer = $null,
+   [int]    $iteration = 0
+)
+
+# definition of the scenario name & scenario ID
+Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_V1"     -Option ReadOnly -Value "AF+EC+BBP"
+Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_ID_V1"  -Option ReadOnly -Value 81968
+Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_V2"     -Option ReadOnly -Value "AF+PL+ECE+BBP+CFA"
+Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_ID_V2"  -Option ReadOnly -Value 2834432
+
+Set-Variable -Name "VIDEO_RECORDING_DURATION"               -Option ReadOnly -Value 20
+Set-Variable -Name "NUMBER_OF_ITERATION"                    -Option ReadOnly -Value 10
+
+function VerifyVideoMode {
+    param ($assessmentScenario, $videoResName, $iter)
+
+    $timeStamp = Get-Date
+    $scenarioLogFolder = "CameraReliabilityTest\$assessmentScenario\iteration_$iter"
+    $wsev2PolicyState = CheckWSEV2Policy
+
+    # Start collecting traces
+    StartTrace $scenarioLogFolder $timeStamp
+
+    StartVideoRecording $VIDEO_RECORDING_DURATION
+
+    # Check if frame server is stopped
+    CheckServiceState 'Windows Camera Frame Server'
+
+    # Stop the trace
+    StopTrace $scenarioLogFolder $timeStamp
+
+    $scenarioID = if ($wsev2PolicyState) {
+        $WSE_ALL_CAMERA_EFFECTS_SCENARIO_ID_V2
+    } else {
+        $WSE_ALL_CAMERA_EFFECTS_SCENARIO_ID_V1
+    }
+
+    return Verifylogs $scenarioLogFolder $scenarioID $timeStamp
+}
+
+function VerifyPhotoMode {
+    param ($iter)
+
+    $timeStamp = Get-Date
+    $scenarioLogFolder = "CameraReliabilityTest\photo\iteration_$iter"
+
+    # Start collecting traces
+    StartTrace $scenarioLogFolder $timeStamp
+
+    StartPhotoCapturing
+
+    # Check if frame server is stopped
+    CheckServiceState 'Windows Camera Frame Server'
+
+    # Stop the trace
+    StopTrace $scenarioLogFolder $timeStamp
+
+    $scenarioID = 0
+    return Verifylogs $scenarioLogFolder $scenarioID $timeStamp
+}
+
+function CameraReliabilityTest {
+    param ($iteration)
+
+    $wsev2PolicyState = CheckWSEV2Policy
+
+    # Tweak camera to use the highest resolution
+    $videoResName = SetHighestVideoResolutionInCameraApp
+
+    $assessmentScenario = if ($wsev2PolicyState) {
+        $WSE_ALL_CAMERA_EFFECTS_SCENARIO_V2
+    } else {
+        $WSE_ALL_CAMERA_EFFECTS_SCENARIO_V1
+    }
+
+    # Toggle all effects on
+    Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to toggle all effects On" -IsOutput
+    ToggleAIEffectsInSettingsApp -AFVal "On" `
+                                 -PLVal "On" `
+                                 -BBVal "On" -BSVal "False" -BPVal "True" `
+                                 -ECVal "On" -ECSVal "False" -ECEVal "True" `
+                                 -VFVal "Off" `
+                                 -CF "On" -CFI "False" -CFA "True" -CFW "False"
+
+    # Check if frame server is stopped
+    CheckServiceState 'Windows Camera Frame Server'
+
+    for ($iter = 1; $iter -le $iteration; $iter++) {
+        Write-Log -Message "`nCameraReliabilityTest [$iter / $iteration] rounds" -IsHost
+
+        if (-not (VerifyVideoMode $assessmentScenario $videoResName $iter)) {
+            Write-Log -Message "Video mode for run ${iter}: FAIL" -IsHost -ForegroundColor Red
+        } else {
+            Write-Log -Message "Video mode for run ${iter}: PASS" -IsHost -ForegroundColor Green
+        }
+
+        if (-not (VerifyPhotoMode $iter)) {
+            Write-Log -Message "Photo mode for run ${iter}: FAIL" -IsHost -ForegroundColor Red
+        } else {
+            Write-Log -Message "Photo mode for run ${iter}: PASS" -IsHost -ForegroundColor Green
+        }
+    }
+
+    # Restore the default state for AI effects
+    Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to Restore the default state for AI effects" `
+              -IsOutput
+    ToggleAIEffectsInSettingsApp -AFVal "Off" `
+                                 -PLVal "Off" `
+                                 -BBVal "Off" -BSVal "False" -BPVal "False" `
+                                 -ECVal "Off" -ECSVal "False" -ECEVal "False" `
+                                 -VFVal "Off" `
+                                 -CF "Off" -CFI "False" -CFA "False" -CFW "False"
+}
+
+# Load helper library and initialize test
+.".\CheckInTest\Helper-library.ps1"
+InitializeTest 'CameraReliabilityTest' `
+               $targetMepCameraVer `
+               $targetMepAudioVer `
+               $targetPerceptionCoreVer
+
+# If the user does not specify the iteration parameter, default to NUMBER_OF_ITERATION.
+if ($iteration -eq 0) {
+   $iteration = $NUMBER_OF_ITERATION
+}
+
+Set-SystemSettingsInCamera
+CameraReliabilityTest $iteration

--- a/E2E/Library/CameraAppHandlers.ps1
+++ b/E2E/Library/CameraAppHandlers.ps1
@@ -223,6 +223,31 @@ function StartVideoRecording($scnds, $devPowStat)
 
 <#
 DESCRIPTION:
+    This function starts the Camera app, switches to photo mode, and takes a photo.
+RETURN TYPE:
+    - void (Taking a photo in Camera app without returning a value.)
+#>
+function StartPhotoCapturing
+{
+    # Open Camera App
+    $ui = OpenApp 'microsoft.windows.camera:' 'Camera'
+    Start-Sleep -Seconds 1
+
+    # Switch to photo mode if not in photo mode
+    SwitchModeInCameraApp $ui "Switch to photo mode" "Take photo"
+    Start-Sleep -Seconds 2
+
+    # Take a photo
+    [System.Windows.Forms.SendKeys]::SendWait(' ')
+    Start-Sleep -Seconds 2
+
+    # Close Camera App
+    CloseApp 'WindowsCamera'
+    Start-Sleep -Seconds 1
+}
+
+<#
+DESCRIPTION:
     This function opens the Camera app, switches to video mode, and starts previewing for a specified duration.
     It captures the app's start time in UTC format, which can be used later for log and performance analysis.
     After the previewing is complete, the Camera app is closed, and the start time is returned.

--- a/E2E/Library/VerifyLogs.ps1
+++ b/E2E/Library/VerifyLogs.ps1
@@ -8,7 +8,7 @@ INPUT PARAMETERS:
     - snarioId [string] :- The scenario ID used to identify specific log entries.
     - strtTime [datetime] :- The start time of the scenario, used for calculating durations.
 RETURN TYPE:
-    - void (Performs validation and logging without returning a value.)
+    - [bool] (Returns `$false` if asg trace is missing in the specified folder or if the target scenario ID was not found; otherwise, returns `$true`)
 #>
 function VerifyLogs($snarioName, $snarioId, $strtTime)
 {  
@@ -21,45 +21,36 @@ function VerifyLogs($snarioName, $snarioId, $strtTime)
       #Find Usage line with desired scenario ID
       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.$snarioId\,.*"
       $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
-      if(($frameProcessingDetails.count -eq 0) -and ($snarioId -eq "96"  -or "16416" -or "65632" -or "81952" -or "112" -or "16432" -or "65648" -or "81968"))
+      if(($frameProcessingDetails.count -eq 0) -and ($snarioId -in @("96", "16416", "65632", "81952", "112", "16432", "65648", "81968")))
       {
-
          switch ($snarioId)
          {
-            "96"  {
+            "96"   {
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.64\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
-                  }
+                   }
             "16416"{
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.16384\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
-            
             "65632"{
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.65600\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
             "81952"{
                        $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.81920\,.*"
-                       $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
             "112"  {
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.80\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
             "16432"{
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.16400\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
             "65648"{
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.65616\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
             "81968"{
                       $pattern = "::PerceptionSessionUsageStats.*PerceptionCore-.*,.81936\,.*"
-                      $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
                    }
          }
+         $frameProcessingDetails = (Select-string -path $pathAsgTraceTxt -Pattern $pattern | Select-Object -Last 1) -split ","
       }
       else 
       {    
@@ -113,13 +104,16 @@ function VerifyLogs($snarioName, $snarioId, $strtTime)
          #Prints Test failed for specific scenario as proper scenarioID was not found.  
          TestOutputMessage $snarioName "Fail" $strtTime "[ScenarioID:$snarioId] was not found."
          Write-Log -Message "[ScenarioID:$snarioId] was not found. Logs saved at $pathAsgTraceLogs" -IsHost -IsOutput >> "$pathLogsFolder\ConsoleResults.txt"
+         return $false
       }
    }
    else
    {
-      Write-Error "$pathAsgTraceTxt not found " -ErrorAction Stop 
+      TestOutputMessage $snarioName "Fail" $strtTime "$pathAsgTraceTxt not found "
+      Write-Log -Message "$pathAsgTraceTxt not found " -IsHost -IsOutput >> "$pathLogsFolder\ConsoleResults.txt"
+      return $false
    }
- 
+   return $true
 }
 
 <#


### PR DESCRIPTION

## What changed?
Perform a check on continuously switching between photo mode and video mode in the Camera app to ensure that the MEP function remains active and that camera streaming is still available.

## Why changed?
To assist silicon and OEM partners in ensuring the reliability of their camera drivers and to maintain the quality of MEP.

## How did you test the change?
Executed CameraReliabilityTest.ps1 on various silicon platforms.

- To run the script, use the command '.\CameraReliabilityTest.ps1 -iteration <integer>'. For example, '.\CameraReliabilityTest.ps1 -iteration 10' will switch between photo and video modes 10 times. If the '-iteration' parameter is not specified by the user, its default value is 10.

## Related Issues (if any):

