### PR TITLE
Check Runner status and schedule tests if its Online

### DIFF
--- a/.github/actions/check-runner-status/action.yaml
+++ b/.github/actions/check-runner-status/action.yaml
@@ -1,0 +1,48 @@
+name: Check Runner Status
+description: Checks if a self-hosted runner with a specific label is online
+
+inputs:
+  label:
+    description: 'Runner label to check'
+    required: true
+  token:
+    description: 'GitHub token'
+    required: true  
+
+outputs:
+  online:
+    description: 'Whether the runner is online'
+    value: ${{ steps.check.outputs.online }}
+
+runs:
+  using: "composite"
+  steps:
+    - id: check
+      shell: powershell
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        $label = "${{ inputs.label }}"
+        $repo = "${{ github.repository }}"
+        $apiUrl = "https://api.github.com/repos/$repo/actions/runners"
+        $headers = @{
+          Authorization = "Bearer $env:GH_TOKEN"
+          Accept        = "application/vnd.github+json"
+          "X-GitHub-Api-Version" = "2022-11-28"
+        }
+        $runners = Invoke-RestMethod -Uri $apiUrl -Headers $headers
+        $isOnline = $false
+        foreach ($runner in $runners.runners) {
+          $labelNames = $runner.labels | ForEach-Object { $_.name.ToLower() }
+          $status = $runner.status
+          $name = $runner.name
+          $label = $label.ToLower()
+
+          Write-Output "Runner found: $name | Status: $status | Labels: $($labelNames -join ', ')"
+
+          if ($labelNames -contains $label -and $runner.status -eq "online") {
+            $isOnline = $true
+            break
+          }
+        }
+        "online=$($isOnline.ToString().ToLower())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append

--- a/.github/workflows/Upload-E2E-Test-Artifact.yml
+++ b/.github/workflows/Upload-E2E-Test-Artifact.yml
@@ -1,9 +1,15 @@
 name: Add Version Details and Upload E2E Tests Artifact
 
-on: [push]
- # push:
-  #  branches:
-     # - main  # Trigger the action on push to the master branch
+on: 
+  push:
+    branches:
+     - main  # Trigger the action on push to the master branch
+
+permissions:
+  contents: write        # Allow write access to repository contents (e.g., pushing changes)
+  pull-requests: write   # Allow write access to pull requests (e.g., create or merge PRs)
+  issues: write          # Allow write access to issues (optional, if needed)
+  actions: write         # Allow write access to Actions (e.g., update or create workflows)
 
 jobs:
   build-and-upload:

--- a/.github/workflows/dispatcher.yaml
+++ b/.github/workflows/dispatcher.yaml
@@ -1,0 +1,77 @@
+name: Check Runner Status and Schedule Tests 
+
+permissions: write-all
+
+on:
+  pull_request:
+    branches:
+      - main
+ 
+jobs:
+  check-runners:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        runner:
+          - id: asus
+            label: "Asus-ProArt"
+          - id: hp
+            label: "HP-REGIS-PV"
+          - id: surface
+            label: "Surface-Pro"
+    outputs:
+      asus-online: ${{ steps.set-output-asus.outputs.value }}
+      hp-online: ${{ steps.set-output-hp.outputs.value }}
+      surface-online: ${{ steps.set-output-surface.outputs.value }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+    
+      - name: Check if ${{ matrix.runner.label }} is online
+        id: check
+        uses: ./.github/actions/check-runner-status
+        with:
+          label: ${{ matrix.runner.label }}
+          token: ${{ secrets.PAT_TOKEN }}
+
+      - name: Set output for ASUS
+        if: matrix.runner.id == 'asus'
+        id: set-output-asus
+        run: echo "value=${{ steps.check.outputs.online }}" >> $env:GITHUB_OUTPUT
+
+      - name: Set output for HP
+        if: matrix.runner.id == 'hp'
+        id: set-output-hp
+        run: echo "value=${{ steps.check.outputs.online }}" >> $env:GITHUB_OUTPUT
+
+      - name: Set output for Surface
+        if: matrix.runner.id == 'surface'
+        id: set-output-surface
+        run: echo "value=${{ steps.check.outputs.online }}" >> $env:GITHUB_OUTPUT
+
+  run-asus-tests:
+    needs: check-runners
+    if: needs.check-runners.outputs.asus-online == 'true'
+    uses: ./.github/workflows/reusable-test-runner.yaml
+    with:
+      runner_label: "Asus-ProArt"
+      device_name: "ASUS-PROART"
+    secrets: inherit
+
+  run-hp-tests:
+    needs: check-runners
+    if: needs.check-runners.outputs.hp-online == 'true'
+    uses: ./.github/workflows/reusable-test-runner.yaml
+    with:
+      runner_label: "HP-REGIS-PV"
+      device_name: "HP-REGIS-PV"
+    secrets: inherit
+
+  run-surface-tests:
+    needs: check-runners
+    if: needs.check-runners.outputs.surface-online == 'true'
+    uses: ./.github/workflows/reusable-test-runner.yaml
+    with:
+      runner_label: "Surface-Pro"
+      device_name: "MICROSOFT-SURFA"
+    secrets: inherit

--- a/.github/workflows/reusable-test-runner.yaml
+++ b/.github/workflows/reusable-test-runner.yaml
@@ -1,0 +1,102 @@
+name: Run Tests on Self-Hosted Runner
+
+on:
+  workflow_call:
+    inputs:
+      runner_label:
+        required: true
+        type: string
+      device_name:
+        required: true
+        type: string
+
+jobs:
+  run-tests:
+    name: Run tests on ${{ inputs.device_name }}
+    runs-on: ${{ inputs.runner_label }}
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pywinauto
+        shell: powershell    
+
+      - name: Run PowerShell Tests
+        shell: powershell
+        working-directory: E2E
+        run: |
+          try {
+              # Run the script and capture all output
+              $testOutput = .\CheckInTest.ps1 *>&1 | Tee-Object -Variable out
+
+              # Check for any test failure in output
+              if ($out -match ":\s*Failed") {
+                  Write-Error "One or more tests failed."
+                  exit 1
+              }
+
+              # Optional: output full logs to console
+              $out | ForEach-Object { Write-Host $_ }
+
+          } catch {
+              Write-Error "Test script threw an exception: $_"
+              exit 1
+          }
+
+      - name: Find the latest log folder
+        if: always()
+        id: find-latest-log
+        shell: powershell
+        working-directory: E2E\logs
+        run: |
+          Write-Output "Changed directory to: $PWD"
+          $logFolders = Get-ChildItem -Directory
+          Write-Output "Log folders found: $($logFolders.Name)"
+          $latestLogFolder = $logFolders | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+          Write-Output "Latest log folder: $latestLogFolder"
+          echo "LOG_FOLDER_NAME=$latestLogFolder" >> $env:GITHUB_ENV
+          echo "LATEST_LOG_FOLDER=$($latestLogFolder.FullName)" >> $env:GITHUB_ENV
+
+      - name: Verify latest log folder contents
+        if: always()
+        shell: powershell
+        run: |
+          Get-ChildItem -Path "${{ env.LATEST_LOG_FOLDER }}" -Recurse
+
+      - name: Set artifact name
+        id: set-artifact-name
+        if: always()
+        shell: powershell
+        run: |
+          $artifactName = "${{ env.LOG_FOLDER_NAME }}-${{ inputs.device_name  }}"
+          echo "ARTIFACT_NAME=$artifactName" >> $env:GITHUB_ENV
+
+      - name: Upload logs from device ${{ inputs.device_name  }}
+        if: ${{ always() && env.LATEST_LOG_FOLDER != '' }}
+        uses: actions/upload-artifact@v4.6.2
+        with:
+          name: ${{ env.ARTIFACT_NAME }}
+          path: ${{ env.LATEST_LOG_FOLDER }}\**
+          if-no-files-found: warn
+          retention-days: 7
+          compression-level: 6
+          overwrite: true
+          include-hidden-files: false
+
+      - name: Test Complete on device ${{ inputs.device_name  }}
+        if: success()
+        run: Write-Output "Test run completed successfully"
+
+      - name: Test Failed on device ${{ inputs.device_name  }}
+        if: failure()
+        run: Write-Output "Test run failed"


### PR DESCRIPTION
What changed?
Added a workflow to check self-hosted runner status and schedule Checkintests for every pull request to the main branch.
Granted write permissions to the .github/workflows/Upload-E2E-Test-Artifact.yml file to create version.txt.

Why was this changed?
To ensure that any new changes do not break existing functionality by validating them automatically through the workflow and adding version to E2E folder.

How was this tested?
The workflow was tested successfully on self-hosted runners and versioning was tested on local branch.

