### PR TITLE
NPU CPU and Memory Utilization is captured during Camera Previewing

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -25,8 +25,8 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
    {  
        $startTime = Get-Date
        $VFdetails= "VF-$VF"
-	    $vdoResDetails= RetrieveValue($vdoRes)
-	    $ptoResDetails= RetrieveValue($ptoRes)       
+	   $vdoResDetails= RetrieveValue($vdoRes)
+	   $ptoResDetails= RetrieveValue($ptoRes)       
        $scenarioLogFolder = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails\$devPowStat\$VFdetails\$toggleEachAiEffect"
        $resourceUtilizationConsolidated = "$pathLogsFolder\$devPowStat-consolidate_stats.txt"
        Write-Log -Message "`nStarting Test for $scenarioLogFolder`n" -IsOutput
@@ -149,14 +149,14 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
        if($camsnario -eq "Recording")
        {
            #Start video recording and close the camera app once finished recording 
-           $InitTimeCameraApp = StartVideoRecording "20" $devPowStat $scenarioLogFolder #video recording duration can be adjusted depending on the number os scenarios
+           $InitTimeCameraApp = StartVideoRecording "20" $devPowStat $scenarioLogFolder $resourceUtilizationConsolidated #video recording duration can be adjusted depending on the number os scenarios
            $cameraAppStartTime = $InitTimeCameraApp[-1]
            Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
        }
        else
        {   
            #Start Previewing and close the camera app once finished. 
-           $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $scenarioLogFolder #video Previewing duration can be adjusted depending on the number os scenarios
+           $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $scenarioLogFolder $resourceUtilizationConsolidated #video Previewing duration can be adjusted depending on the number os scenarios
            $cameraAppStartTime = $InitTimeCameraApp[-1]
            Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
        }

--- a/E2E/CheckInTest/Camerae2eTest.ps1
+++ b/E2E/CheckInTest/Camerae2eTest.ps1
@@ -68,6 +68,7 @@ function Camera-App-Playlist($devPowStat, $token, $SPId)
         $uitaskmgr = OpenApp 'Taskmgr' 'Task Manager'
         Start-Sleep -s 1
         setTMUpdateSpeedLow -uiEle $uitaskmgr
+        
         # Call python modules for task manager Before starting the test case
         Start-Process -FilePath "python" -ArgumentList $pythonLibFolder, "start_resource_monitoring", $resourceUtilizationFile, $scenarioLogFolder, 5 -NoNewWindow -RedirectStandardOutput $resourceUtilizationConsolidated -Wait                     
         $utilizationStats = GetResourceUtilizationStats $resourceUtilizationConsolidated
@@ -76,14 +77,15 @@ function Camera-App-Playlist($devPowStat, $token, $SPId)
             Write-Error "Failed to get resource utilization stats."
             return
         }
+        
         # Start video recording and close the camera app once finished recording 
         Write-Log -Message "Entering StartVideoRecording function" -IsOutput
         $InitTimeCameraApp = StartVideoRecording "60" $devPowStat $scenarioLogFolder
         $cameraAppStartTime = $InitTimeCameraApp[-1]
         Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
 
-        # Capture CPU and NPU Usage
-        Write-Log -Message "Entering CPUandNPU-Usage function to capture CPU and NPU usage Screenshot" -IsOutput
+        # Close Task Manager and take Screenshot of CPU and NPU Usage
+        Write-Log -Message "Entering stopTaskManager function to Close Task Manager and capture CPU and NPU usage Screenshot" -IsOutput
         stopTaskManager -uitaskmgr $uitaskmgr -Scenario $scenarioLogFolder
         
         $utilizationStats = GetResourceUtilizationStats $resourceUtilizationConsolidated

--- a/E2E/CheckInTest/Camerae2eTest.ps1
+++ b/E2E/CheckInTest/Camerae2eTest.ps1
@@ -80,7 +80,7 @@ function Camera-App-Playlist($devPowStat, $token, $SPId)
         
         # Start video recording and close the camera app once finished recording 
         Write-Log -Message "Entering StartVideoRecording function" -IsOutput
-        $InitTimeCameraApp = StartVideoRecording "60" $devPowStat $scenarioLogFolder
+        $InitTimeCameraApp = StartVideoRecording "60" $devPowStat $scenarioLogFolder $resourceUtilizationConsolidated
         $cameraAppStartTime = $InitTimeCameraApp[-1]
         Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
 

--- a/E2E/CheckInTest/Min-Max-CameraApp.ps1
+++ b/E2E/CheckInTest/Min-Max-CameraApp.ps1
@@ -82,7 +82,7 @@ function Min-Max-CameraApp($devPowStat, $token, $SPId)
         setTMUpdateSpeedLow -uiEle $uitaskmgr
 
         # Open camera App
-        $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $logFile
+        $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $logFile $resourceUtilizationConsolidated
         $cameraAppStartTime = $InitTimeCameraApp[-1]
         Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
         

--- a/E2E/CheckInTest/ToggleAIEffectsMultipleTimes.ps1
+++ b/E2E/CheckInTest/ToggleAIEffectsMultipleTimes.ps1
@@ -42,7 +42,7 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
     $ErrorActionPreference='Stop'
     $scenarioName = "$devPowStat\ToggleAIEffectsMultipleTimes"
     $logFile = "$devPowStat-ToggleAIEffectsMultipleTimes.txt"
-    
+    $resourceUtilizationConsolidated = "$pathLogsFolder\$devPowStat-consolidate_stats.txt"
     $devState = CheckDevicePowerState $devPowStat $token $SPId
     if($devState -eq $false)
     {   
@@ -203,7 +203,7 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
         setTMUpdateSpeedLow -uiEle $uitaskmgr
 
         # Open camera App
-        $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $logFile
+        $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $logFile $resourceUtilizationConsolidated
         $cameraAppStartTime = $InitTimeCameraApp[-1]
         Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
 

--- a/E2E/CheckInTest/ToggleAIEffectsMultipleTimes.ps1
+++ b/E2E/CheckInTest/ToggleAIEffectsMultipleTimes.ps1
@@ -195,12 +195,29 @@ function ToggleAIEffectsMultipleTimes($devPowStat, $token, $SPId)
         # Starting to collect Traces
         Write-Log -Message "Entering StartTrace function" -IsOutput
         StartTrace $scenarioName
+        
+        # Open Task Manager
+        Write-Log -Message "Opening Task Manager" -IsOutput
+        $uitaskmgr = OpenApp 'Taskmgr' 'Task Manager'
+        Start-Sleep -s 1
+        setTMUpdateSpeedLow -uiEle $uitaskmgr
 
         # Open camera App
-        $InitTimeCameraApp = CameraPreviewing "20"
+        $InitTimeCameraApp = CameraPreviewing "20" $devPowStat $logFile
         $cameraAppStartTime = $InitTimeCameraApp[-1]
         Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
+
+        # Close Task Manager and take Screenshot of CPU and NPU Usage
+        Write-Log -Message "Entering stopTaskManager function to Close Task Manager and capture CPU and NPU usage Screenshot" -IsOutput
+        stopTaskManager -uitaskmgr $uitaskmgr -Scenario $scenarioLogFolder
         
+        $utilizationStats = GetResourceUtilizationStats $resourceUtilizationConsolidated
+
+        if ($null -eq $utilizationStats) {
+            Write-Error "Failed to get resource utilization stats."
+            return
+        }
+
         # Checks if frame server is stopped
         Write-Log -Message "Entering CheckServiceState function" -IsOutput
         CheckServiceState 'Windows Camera Frame Server'

--- a/E2E/Library/CameraAppHandlers.ps1
+++ b/E2E/Library/CameraAppHandlers.ps1
@@ -172,7 +172,7 @@ INPUT PARAMETERS:
 RETURN TYPE:
     - [DateTime] (Returns the start time of the video recording in UTC format.)
 #>
-function StartVideoRecording($scnds, $devPowStat, $scenarioLogFolder)
+function StartVideoRecording($scnds, $devPowStat, $scenarioLogFolder, $resourceUtilizationConsolidated)
 {  
      $pythonLibFolder = ".\Library\python\npu_cpu_memory_utilization.py"
      $resourceUtilizationFile = "$pathLogsFolder\$devPowStat-resource_utilization.txt"
@@ -262,7 +262,7 @@ INPUT PARAMETERS:
 RETURN TYPE:
     - [DateTime] (Returns the start time of the Camera app in UTC format for later time calculations.)
 #>
-function CameraPreviewing($scnds, $devPowStat, $scenarioLogFolder)
+function CameraPreviewing($scnds, $devPowStat, $scenarioLogFolder, $resourceUtilizationConsolidated)
 {  
      $pythonLibFolder = ".\Library\python\npu_cpu_memory_utilization.py"
      $resourceUtilizationFile = "$pathLogsFolder\$devPowStat-resource_utilization.txt"


### PR DESCRIPTION
## What changed?

CameraAppTest.ps1 is updated to capture NPU CPU and Memory Utilization during Camera Previewing scenario.
CameraPreviewing funcion in CameraAppHandler.cs is updated to capture NPU CPU and Memory Utilization during Camera Previewing scenario.

## Why changed?

NPU CPU utilization was getting captured only for CameraRecording scenario and not during CameraPreviewing scenario. Added functionality for camreapreviewing as well.

## How did you test the change?

Executed ReleaseTest and CheckinTest

## Related Issues (if any):

[Report.xlsx](https://github.com/user-attachments/files/20379761/Report.xlsx)
