### PR TITLE
Added to functionality to generate combination of scenarios from a given set and assign values.

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -33,8 +33,8 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
        Write-Log -Message "Creating the log folder" -IsOutput       
        CreateScenarioLogsFolder $scenarioLogFolder
 
-       #Retrieve value for scenario from Hash table
-       $toggleEachAiEffect = RetrieveValue $toggleEachAiEffect
+       #Retrieve value for scenario from Get-CombinationReturnValues function
+       $toggleEachAiEffect = Get-CombinationReturnValues -effects $toggleEachAiEffect
        if($toggleEachAiEffect.length -eq 0)
        {
           TestOutputMessage $scenarioLogFolder "Skipped" $startTime "wsev2Policy Not Supported"

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -31,43 +31,75 @@ function GetDeviceDetails()
    {
       $deviceData.VoiceFocus    = @("On", "Off")
    }
+   $testScenarios = Generate-Combinations
+   $deviceData.ToggleAiEffect = $testScenarios
+   
+   return $deviceData
+}
+<#
+DESCRIPTION:
+    Generates all valid combinations of camera features based on WSEV2 policy state.
+    Each combination is a '+'-joined string of selected features.
+
+INPUT:
+    - None
+
+RETURN TYPE:
+    - [string[]] : An array of non-empty feature combinations.
+
+NOTES:
+    - Feature options change depending on whether the WSEV2 policy is enabled.
+    - Skips empty combinations (i.e., when no features are selected).
+#>
+function Generate-Combinations
+{
    $wsev2PolicyState = CheckWSEV2Policy
-   if($wsev2PolicyState -eq $false)	  
-   {
-      $deviceData.ToggleAiEffect   = @("AF","EC","BBS", "BBP","AF+EC", "AF+BBS", "AF+BBP","BBS+EC","BBP+EC","AF+BBS+EC","AF+BBP+EC")
+   if($wsev2PolicyState -eq $false)	
+   {  
+      # Define options
+      $AFOptions = @("", "AF")
+      $PLOptions = @("")
+      $ECOptions = @("", "ECS")
+      $BlurOptions = @("", "BBP", "BBS")
+      $CFOptions = @("")
    }
    else
    {
-      $deviceData.ToggleAiEffect   = @('AF', 'PL', 'BBS', 'BBP', 'EC', 'ECE', 'AF+PL', 'AF+BBS', 'AF+BBP', 'AF+EC', 'AF+ECE', `
-                     'PL+BBS', 'PL+BBP', 'PL+EC', 'PL+ECE', 'BBS+EC', 'BBS+ECE', 'BBP+EC', 'BBP+ECE', 'AF+PL+BBS', `
-                     'AF+PL+BBP','AF+PL+EC', 'AF+PL+ECE', 'AF+BBS+EC', 'AF+BBS+ECE', 'AF+BBP+EC', 'AF+BBP+ECE', `
-                     'Pl+BBS+EC', 'Pl+BBP+EC', 'Pl+BBS+ECE', 'Pl+BBP+ECE', 'AF+Pl+BBS+EC', 'AF+Pl+BBS+ECE', `
-                     'AF+Pl+BBP+EC', 'AF+Pl+BBP+ECE','CF-I', 'AF+CF-I', 'AF+CF-I+PL', 'AF+CF-I+EC', `
-                     'AF+CF-I+ECE', 'AF+CF-I+BBS', 'AF+CF-I+BBP', 'AF+CF-I+PL+EC', 'AF+CF-I+PL+ECE', `
-                     'AF+CF-I+PL+BBS', 'AF+CF-I+PL+BBP', 'AF+CF-I+EC+BBS', 'AF+CF-I+EC+BBP', 'AF+CF-I+ECE+BBS', `
-                     'AF+CF-I+ECE+BBP', 'AF+CF-I+PL+EC+BBS', 'AF+CF-I+PL+EC+BBP', 'AF+CF-I+PL+ECE+BBS', `
-                     'AF+CF-I+PL+ECE+BBP', 'PL+CF-I', 'PL+CF-I+EC', 'PL+CF-I+ECE', 'PL+CF-I+BBS', `
-                     'PL+CF-I+BBP', 'PL+CF-I+EC+BBS', 'PL+CF-I+EC+BBP', 'PL+CF-I+ECE+BBS', 'PL+CF-I+ECE+BBP', `
-                     'EC+CF-I', 'ECE+CF-I', 'EC+CF-I+BBS', 'EC+CF-I+BBP', 'ECE+CF-I+BBS', 'ECE+CF-I+BBP', `
-                     'BBS+CF-I', 'BBP+CF-I','CF-A', 'AF+CF-A', 'AF+CF-A+PL', 'AF+CF-A+EC', 'AF+CF-A+ECE', `
-                     'AF+CF-A+BBS', 'AF+CF-A+BBP', 'AF+CF-A+PL+EC', 'AF+CF-A+PL+ECE', 'AF+CF-A+PL+BBS', `
-                     'AF+CF-A+PL+BBP', 'AF+CF-A+EC+BBS', 'AF+CF-A+EC+BBP', 'AF+CF-A+ECE+BBS', 'AF+CF-A+ECE+BBP', `
-                     'AF+CF-A+PL+EC+BBS', 'AF+CF-A+PL+EC+BBP', 'AF+CF-A+PL+ECE+BBS', 'AF+CF-A+PL+ECE+BBP', 'PL+CF-A', `
-                     'PL+CF-A+EC', 'PL+CF-A+ECE', 'PL+CF-A+BBS', 'PL+CF-A+BBP', 'PL+CF-A+EC+BBS', 'PL+CF-A+EC+BBP', `
-                     'PL+CF-A+ECE+BBS', 'PL+CF-A+ECE+BBP', 'EC+CF-A', 'ECE+CF-A', 'EC+CF-A+BBS', 'EC+CF-A+BBP', `
-                     'ECE+CF-A+BBS', 'ECE+CF-A+BBP', 'BBS+CF-A', 'BBP+CF-A','CF-W', 'AF+CF-W', 'AF+CF-W+PL', `
-                     'AF+CF-W+EC', 'AF+CF-W+ECE', 'AF+CF-W+BBS', 'AF+CF-W+BBP', 'AF+CF-W+PL+EC', 'AF+CF-W+PL+ECE', `
-                     'AF+CF-W+PL+BBS', 'AF+CF-W+PL+BBP', 'AF+CF-W+EC+BBS', 'AF+CF-W+EC+BBP', 'AF+CF-W+ECE+BBS', `
-                     'AF+CF-W+ECE+BBP', 'AF+CF-W+PL+EC+BBS', 'AF+CF-W+PL+EC+BBP', 'AF+CF-W+PL+ECE+BBS', `
-                     'AF+CF-W+PL+ECE+BBP', 'PL+CF-W', 'PL+CF-W+EC', 'PL+CF-W+ECE', 'PL+CF-W+BBS', 'PL+CF-W+BBP', `
-                     'PL+CF-W+EC+BBS', 'PL+CF-W+EC+BBP', 'PL+CF-W+ECE+BBS', 'PL+CF-W+ECE+BBP', 'EC+CF-W', `
-                     'ECE+CF-W', 'EC+CF-W+BBS', 'EC+CF-W+BBP', 'ECE+CF-W+BBS', 'ECE+CF-W+BBP', 'BBS+CF-W', 'BBP+CF-W')
-   }       
-           
-
-   return $deviceData
+      # Define options
+      $AFOptions = @("", "AF")
+      $PLOptions = @("", "PL")
+      $ECOptions = @("", "ECT", "ECS")
+      $BlurOptions = @("", "BBP", "BBS")
+      $CFOptions = @("", "CF-I", "CF-A", "CF-W")
+   }
+   $combinations = @()
+   
+   foreach ($af in $AFOptions) {
+       foreach ($pl in $PLOptions) {
+           foreach ($ec in $ECOptions) {
+               foreach ($blur in $BlurOptions) {
+                   foreach ($cf in $CFOptions) {
+   
+                       # Create an array of chosen options, ignoring empty strings
+                       $selected = @($af, $pl, $ec, $blur, $cf) | Where-Object { $_ -ne "" }
+   
+                       # Skip empty combination
+                       if ($selected.Count -eq 0) {
+                           continue
+                       }
+   
+                       # Format combination string (joined by '+')
+                       $comboString = $selected -join "+"
+   
+                       # Add to list
+                       $combinations += $comboString
+                       #$combinations | Sort-Object | ForEach-Object { Write-Host $_ }
+                   }
+               }
+           }
+       }
+   }return $combinations
 }
-
 <#
 DESCRIPTION:
     This function retrieves the list of supported video resolutions from the Camera app settings.


### PR DESCRIPTION
What?
Added functionality to dynamically generate combinations of individual scenarios from a given set. Each combination is assigned a scenario ID and toggle options. The logic replaces the previously hardcoded entries in LookUpTable.ps1.

- Scenario IDs and combinations are now generated programmatically.
- Toggle options are assigned based on the combination logic.

Task:
https://microsoft.visualstudio.com/OS/_queries/edit/57541638/?triage=true 
https://microsoft.visualstudio.com/OS/_queries/edit/56766813/?triage=true 

Why?
Currently, scenario IDs and their combinations are hardcoded in LookUpTable.ps1. This update automates the process, improving maintainability and reducing manual effort.

How verified?
Ran ReleaseTest.ps1

pipeline reference, if any:
Screenshot of validation for E2E:
image.png<img width="397" alt="image" src="https://github.com/user-attachments/assets/262ef74e-6318-4d94-8443-a8bd9de19ed9" />


![Screenshot 2025-05-29 163111](https://github.com/user-attachments/assets/80f03957-280d-41e3-b359-e114fcde84a8)
