### PR TITLE
Updated the abbreviation for Eyecontact

### DIFF
--- a/E2E/CheckInTest.ps1
+++ b/E2E/CheckInTest.ps1
@@ -11,7 +11,7 @@ InitializeTest 'Checkin-Test' $targetMepCameraVer $targetMepAudioVer $targetPerc
 
 foreach($devPowStat in "Pluggedin", "Unplugged")
 {  
-   foreach($testScenario in 'AF', 'BBS', 'BBP', 'EC', 'ECE', 'PL', 'CF-I', 'CF-A', 'CF-W')
+   foreach($testScenario in 'AF', 'BBS', 'BBP', 'ECS', 'ECT', 'PL', 'CF-I', 'CF-A', 'CF-W')
    {
       SettingAppTest-Playlist -devPowStat $devPowStat -testScenario $testScenario -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-SettingAppTest.txt"
    }


### PR DESCRIPTION
## What changed?
Changed the abbreviation for Eye contact to match with recently added functio function Get-CombinationReturnValues

## Why changed?
Updated to ECS and ECT to match with recently added function Get-CombinationReturnValues.

## How did you test the change?
Ran check-in test on Arm device

## Related Issues (if any):

