### PR TITLE
Scrolling setting page to the end to load all UI elements

### DIFF
--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -19,7 +19,10 @@ function FindCameraEffectsPage($uiEle){
     else
     {
         FindAndClick $uiEle Button "Connected enabled camera $Global:validatedCameraFriendlyName"
-    }  
+    }
+    Start-Sleep -s 1
+    [System.Windows.Forms.SendKeys]::SendWait('{END}') 
+    Start-Sleep -s 1   
 }
 
 <#


### PR DESCRIPTION
## What changed?
Added logic to scroll the settings page to bottom to ensure all AI effects UI elements are generated & accessible before toggling the effects.

## Why changed?
Intermittently failing to locate the UI elements due the expansion of AI effects.

## How did you test the change?
Tested on 8480

## Related Issues (if any):

