### PR TITLE
To resolve the runtime error observed during execution of CameraRelia…

### DIFF
--- a/E2E/CameraReliabilityTest.ps1
+++ b/E2E/CameraReliabilityTest.ps1
@@ -10,7 +10,7 @@ param (
 # definition of the scenario name & scenario ID
 Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_V1"     -Option ReadOnly -Value "AFS+EC+BBP"
 Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_ID_V1"  -Option ReadOnly -Value 81968
-Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_V2"     -Option ReadOnly -Value "AFC+PL+ECS+BBP+CFA"
+Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_V2"     -Option ReadOnly -Value "AFC+PL+ECS+BBP+CFW"
 Set-Variable -Name "WSE_ALL_CAMERA_EFFECTS_SCENARIO_ID_V2"  -Option ReadOnly -Value 2703376
 Set-Variable -Name "VIDEO_RECORDING_DURATION"               -Option ReadOnly -Value 20
 Set-Variable -Name "NUMBER_OF_ITERATION"                    -Option ReadOnly -Value 10
@@ -25,7 +25,7 @@ function VerifyVideoMode {
     # Start collecting traces
     StartTrace $scenarioLogFolder $timeStamp
 
-    StartVideoRecording $VIDEO_RECORDING_DURATION
+    StartVideoRecording -duration 6 -snarioName $scenarioLogFolder -logPath "$scenarioLogFolder\ResourceUtilization.txt"
 
     # Check if frame server is stopped
     CheckServiceState 'Windows Camera Frame Server'
@@ -84,7 +84,7 @@ function CameraReliabilityTest {
                                  -BBVal "On" -BSVal "False" -BPVal "True" `
                                  -ECVal "On" -ECSVal "True" -ECTVal "False" `
                                  -VFVal "Off" `
-                                 -CF "On" -CFI "False" -CFA "True" -CFW "False"
+                                 -CF "On" -CFI "False" -CFA "False" -CFW "True"
 
     # Check if frame server is stopped
     CheckServiceState 'Windows Camera Frame Server'


### PR DESCRIPTION
To resolve the runtime error observed during execution of CameraReliabilityTest

* To resolve the runtime error observed during execution of CameraReliabilityTest

* To ensure consistency with other end‑to‑end camera testing scenarios by replacing CF‑Animation with CF‑Watercolor

## What changed?
To resolve the runtime error observed during execution of CameraReliabilityTest

## Why changed?
The updated _StartVideoRecording_ behavior has not yet been applied to CameraReliabilityTest.

## How did you test the change?
run CameraReliabilityTest without any issue

## Related Issues (if any):
NA

