### PR TITLE
User/jdugar/runtestwithdeviceunpluggedand pluggedwithout smartplug

### DIFF
--- a/E2E/CheckInTest.ps1
+++ b/E2E/CheckInTest.ps1
@@ -3,23 +3,25 @@
    [string] $SPId = $null,
    [string] $targetMepCameraVer = $null,
    [string] $targetMepAudioVer = $null,
-   [string] $targetPerceptionCoreVer = $null
+   [string] $targetPerceptionCoreVer = $null,
+
+   [ValidateSet("Pluggedin","Unplugged")]
+   [string[]] $devicePowerState = @("Pluggedin","Unplugged")
 )
 .".\CheckInTest\Helper-library.ps1"
-
 InitializeTest 'Checkin-Test' $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer
 
-foreach($devPowStat in "Pluggedin", "Unplugged")
+foreach($devPowStat in $devicePowerState)
 {  
-   foreach($testScenario in 'AFS', 'AFC','BBS', 'BBP', 'ECS', 'ECT', 'PL', 'CF-I', 'CF-A', 'CF-W')
-   {
-      SettingAppTest-Playlist -devPowStat $devPowStat -testScenario $testScenario -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-SettingAppTest.txt"
-   }
-   VoiceFocus-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-VoiceFocus.txt"
+  foreach($testScenario in 'AFS', 'AFC','BBS', 'BBP', 'ECS', 'ECT', 'PL', 'CF-I', 'CF-A', 'CF-W')
+  {
+     SettingAppTest-Playlist -devPowStat $devPowStat -testScenario $testScenario -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-SettingAppTest.txt"
+  }
+  VoiceFocus-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-VoiceFocus.txt"
    
-   Camera-App-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-Camerae2eTest.txt"
+  Camera-App-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-Camerae2eTest.txt"
    
-   Voice-Recorder-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-VoiceRecordere2eTest.txt"
+  Voice-Recorder-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-VoiceRecordere2eTest.txt"
 
 }
 #Turn on the smart plug 
@@ -30,5 +32,3 @@ if($token.Length -ne 0 -and $SPId.Length -ne 0)
 
 ConvertTxtFileToExcel "$pathLogsFolder\Report.txt"
 [console]::beep(500,300)
-
-Start-Sleep -s 3

--- a/E2E/Library/SmartPlug.ps1
+++ b/E2E/Library/SmartPlug.ps1
@@ -136,7 +136,8 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
          $chargingState = Get-ChargingState 
          if($chargingState -ne "Discharging")
          {
-            Write-host "Requested Power state:$devPowStat -Either smartplug details are missing or device is in charging state" -ForegroundColor Yellow
+            #Write-host "Requested Power state:$devPowStat -Either smartplug details are missing or device is in charging state" -ForegroundColor Yellow
+            Write-host ("Requested Power State: {0}. Unable to change power state because smartplug details (token and SPId) are missing and current charging state is '{1}'" -f $devPowStat, $chargingState) -ForegroundColor yellow
             return $false
             
          }
@@ -155,11 +156,11 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
       else
       {   
          $chargingState = Get-ChargingState 
-         if($chargingState -ne "Charging")
+         if($chargingState -eq "Discharging")
          {
             # Assumptions by default device is in pluggedIn mode
-            Write-host "$devPowStat Scenario not valid - Currently device is not in charging state" -BackgroundColor Red
-            exit 1
+            Write-host ("Requested Power State: {0}. Unable to change power state because smartplug details (token and SPId) are missing and current charging state is '{1}'" -f $devPowStat, $chargingState) -ForegroundColor yellow
+            return $false
          }
          else
          {

--- a/E2E/Library/SmartPlug.ps1
+++ b/E2E/Library/SmartPlug.ps1
@@ -134,15 +134,13 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
       else
       {  
          $chargingState = Get-ChargingState 
-         if($chargingState -ne "Discharging")
+         if($chargingState -ne "Charging")
          {
-            Write-host "Requested Power state:$devPowStat -Either smartplug details are missing or device is in charging state" -ForegroundColor Yellow
-            return $false
-            
+            return $true
          }
          else
          { 
-            return $true
+            return $false
          }
       }
    }
@@ -157,9 +155,7 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
          $chargingState = Get-ChargingState 
          if($chargingState -ne "Charging")
          {
-            # Assumptions by default device is in pluggedIn mode
-            Write-host "$devPowStat Scenario not valid - Currently device is not in charging state" -BackgroundColor Red
-            exit 1
+            Write-Error " $devPowStat Scenario not valid-Currently device is not in charing state " -ErrorAction Stop 
          }
          else
          {

--- a/E2E/Library/SmartPlug.ps1
+++ b/E2E/Library/SmartPlug.ps1
@@ -132,8 +132,18 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
          SetSmartPlugState $token $SPId 0
       }
       else
-      {   
-         return $false
+      {  
+         $chargingState = Get-ChargingState 
+         if($chargingState -ne "Discharging")
+         {
+            Write-host "Requested Power state:$devPowStat -Either smartplug details are missing or device is in charging state" -ForegroundColor Yellow
+            return $false
+            
+         }
+         else
+         { 
+            return $true
+         }
       }
    }
    elseif($devPowStat -eq "Pluggedin")
@@ -143,8 +153,18 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
          SetSmartPlugState $token $SPId 1
       }
       else
-      {
-         Write-Log -Message "SmartPlug details not available, however the device should be Plugged-In state" -IsOutput
+      {   
+         $chargingState = Get-ChargingState 
+         if($chargingState -ne "Charging")
+         {
+            # Assumptions by default device is in pluggedIn mode
+            Write-host "$devPowStat Scenario not valid - Currently device is not in charging state" -BackgroundColor Red
+            exit 1
+         }
+         else
+         {
+            return $true
+         }
       }
    }
    else

--- a/E2E/Library/SmartPlug.ps1
+++ b/E2E/Library/SmartPlug.ps1
@@ -134,13 +134,15 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
       else
       {  
          $chargingState = Get-ChargingState 
-         if($chargingState -ne "Charging")
+         if($chargingState -ne "Discharging")
          {
-            return $true
+            Write-host "Requested Power state:$devPowStat -Either smartplug details are missing or device is in charging state" -ForegroundColor Yellow
+            return $false
+            
          }
          else
          { 
-            return $false
+            return $true
          }
       }
    }
@@ -155,7 +157,9 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
          $chargingState = Get-ChargingState 
          if($chargingState -ne "Charging")
          {
-            Write-Error " $devPowStat Scenario not valid-Currently device is not in charing state " -ErrorAction Stop 
+            # Assumptions by default device is in pluggedIn mode
+            Write-host "$devPowStat Scenario not valid - Currently device is not in charging state" -BackgroundColor Red
+            exit 1
          }
          else
          {

--- a/E2E/Library/SmartPlug.ps1
+++ b/E2E/Library/SmartPlug.ps1
@@ -136,10 +136,8 @@ function CheckDevicePowerState($devPowStat, $token, $SPId)
          $chargingState = Get-ChargingState 
          if($chargingState -ne "Discharging")
          {
-            #Write-host "Requested Power state:$devPowStat -Either smartplug details are missing or device is in charging state" -ForegroundColor Yellow
             Write-host ("Requested Power State: {0}. Unable to change power state because smartplug details (token and SPId) are missing and current charging state is '{1}'" -f $devPowStat, $chargingState) -ForegroundColor yellow
             return $false
-            
          }
          else
          { 


### PR DESCRIPTION
## What changed?
Added support to run tests with device unplugged without having Smartplug support
Enhanced CheckDevicePowerState logic:
Added fallback validation using Get-ChargingState when SmartPlug details are not available.
Ensures correct behavior for both Pluggedin and Unplugged scenarios.

## Why changed?
To make the test workflow more flexible and reusable across different power scenarios.
To support execution even when SmartPlug is not configured or unavailable.
To improve reliability by validating actual device charging state instead of assuming power state.

## How did you test the change?
Ran test for device plugged In 
<img width="980" height="227" alt="image" src="https://github.com/user-attachments/assets/7fc772b5-2dbd-4750-9559-98ee6bcfd95b" />

Ran test for Plugged in but Unplugged device manually
<img width="1057" height="223" alt="image" src="https://github.com/user-attachments/assets/d0034a78-1f9a-4865-8922-73a906788357" />

Ran test for device unplugged
<img width="1009" height="248" alt="image" src="https://github.com/user-attachments/assets/21ab6d7a-2c5f-4037-b354-4baae194e214" />

Ran test for device unplugged but manually plugged in the device.
<img width="1012" height="233" alt="image" src="https://github.com/user-attachments/assets/ea7caaaf-b723-48c4-b07e-1566b974c701" />

Ran for default parameter 
![Uploading image.png…]()


## Related Issues (if any):

