### PR TITLE
Retrieve the audioEnhancementOptions value from the registry

### DIFF
--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -109,14 +109,22 @@ function FindVoiceFocusPage($uiEle){
     } 
     FindAndClick $uiEle ComboBox "Audio enhancements"
     Start-Sleep -m 500
-    Foreach($audioEnhancementOptions in "Microsoft Windows Studio Voice Focus" , "Windows Studio Effects Voice Clarity")
+
+    $getAudioEffectPackResult = GetWseAudioEffectPackFriendlyName
+    if ($getAudioEffectPackResult.Success) {
+        Write-Log -Message " WSE Audio Effect Pack Friendly Name: $($getAudioEffectPackResult.FriendlyName) " -IsOutput
+    } else {
+        Write-Error " WSE Audio Effect Pack friendly name not found " -ErrorAction Stop
+    }
+
+    $exists = CheckIfElementExists $uiEle ComboBoxItem $getAudioEffectPackResult.FriendlyName
+    if ($exists)
     {
-       $exists = CheckIfElementExists $uiEle ComboBoxItem  $audioEnhancementOptions
-       if ($exists)
-       {
-           FindAndClick $uiEle ComboBoxItem $audioEnhancementOptions
-       }
-    
+        FindAndClick $uiEle ComboBoxItem $getAudioEffectPackResult.FriendlyName
+    }
+    else
+    {
+        Write-Error "ComboBoxItem for $($getAudioEffectPackResult.FriendlyName) not found in Audio enhancements" -ErrorAction Stop
     }
 }
 

--- a/E2E/Library/WseEnablingStatus.ps1
+++ b/E2E/Library/WseEnablingStatus.ps1
@@ -545,3 +545,137 @@ function WseEnablingStatus($targetMepCameraVer, $targetMepAudioVer, $targetPerce
         return $false
     }
 }
+
+<#
+.SYNOPSIS
+    Tries to read the friendly name from a specific registry view.
+
+.PARAMETER RegistryView
+    The registry view to use (Registry64 or Registry32).
+
+.OUTPUTS
+    Returns the friendly name string if found; otherwise empty string.
+#>
+function Get-FriendlyNameFromView {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [Microsoft.Win32.RegistryView]$RegistryView
+    )
+
+    # Registry constants
+    $MepAudioClassGuid = "{5989fce8-9cd0-467d-8a6a-5419e31529d4}"
+    $MepAudioClassKeyPath = "SYSTEM\CurrentControlSet\Control\Class\$MepAudioClassGuid"
+    $MepAudioEffectPackGuid = "{D38F837A-9439-4256-8D63-DD5885442FA2}"
+    $MepAudioFriendlyNameValue = "{B725F130-47EF-101A-A5F1-02608C9EEBAC},10"
+
+    try {
+        # Open the base key with the specified view
+        $baseKey = [Microsoft.Win32.RegistryKey]::OpenBaseKey(
+            [Microsoft.Win32.RegistryHive]::LocalMachine,
+            $RegistryView
+        )
+
+        if ($null -eq $baseKey) {
+            return [string]::Empty
+        }
+
+        try {
+            # Open the class key
+            $classKey = $baseKey.OpenSubKey($MepAudioClassKeyPath, $false)
+
+            if ($null -eq $classKey) {
+                return [string]::Empty
+            }
+
+            try {
+                # Iterate subkeys like "0000", "0001", etc. under the class key
+                $subKeyNames = $classKey.GetSubKeyNames()
+
+                foreach ($subName in $subKeyNames) {
+                    $effectRegPath = "$subName\EffectPackRegistration\$MepAudioEffectPackGuid"
+
+                    $effectRegKey = $classKey.OpenSubKey($effectRegPath, $false)
+
+                    if ($null -eq $effectRegKey) {
+                        continue
+                    }
+
+                    try {
+                        # Get the friendly name value
+                        $value = $effectRegKey.GetValue(
+                            $MepAudioFriendlyNameValue,
+                            $null,
+                            [Microsoft.Win32.RegistryValueOptions]::DoNotExpandEnvironmentNames
+                        )
+
+                        if (($null -ne $value) -and ($value -is [string]) -and (-not [string]::IsNullOrWhiteSpace($value))) {
+                            return $value
+                        }
+                    }
+                    finally {
+                        $effectRegKey.Close()
+                    }
+                }
+            }
+            finally {
+                $classKey.Close()
+            }
+        }
+        finally {
+            $baseKey.Close()
+        }
+    }
+    catch [UnauthorizedAccessException] {
+        # HKLM read should normally be allowed; if not, return empty gracefully
+        Write-Verbose "UnauthorizedAccessException when accessing registry view $RegistryView"
+        return [string]::Empty
+    }
+    catch {
+        # Swallow non-fatal exceptions and continue
+        Write-Verbose "Exception when accessing registry view $RegistryView : $_"
+        return [string]::Empty
+    }
+
+    return [string]::Empty
+}
+
+<#
+.SYNOPSIS
+    Attempts to read the WSE Audio Effect Pack friendly name from the registry.
+
+.DESCRIPTION
+    Tries both 64-bit and 32-bit registry views to cover WOW64 scenarios.
+
+.OUTPUTS
+    Returns a hashtable with 'Success' (bool) and 'FriendlyName' (string) properties.
+#>
+function GetWseAudioEffectPackFriendlyName {
+    [CmdletBinding()]
+    param()
+
+    # Registry views to probe: 64-bit first, then 32-bit
+    $registryViews = @(
+        [Microsoft.Win32.RegistryView]::Registry64,
+        [Microsoft.Win32.RegistryView]::Registry32
+    )
+
+    $friendlyName = [string]::Empty
+
+    foreach ($view in $registryViews) {
+        $name = Get-FriendlyNameFromView -RegistryView $view
+
+        if (-not [string]::IsNullOrWhiteSpace($name)) {
+            $friendlyName = $name
+            return @{
+                Success = $true
+                FriendlyName = $friendlyName
+            }
+        }
+    }
+
+    return @{
+        Success = $false
+        FriendlyName = [string]::Empty
+    }
+}


### PR DESCRIPTION
## What changed?
Retrieve the audioEnhancementOptions value from the registry

## Why changed?
Hardcoding enum values like "_Microsoft Windows Studio Voice Focus_" and "_Windows Studio Effects Voice Clarity_" introduces maintenance limitations due to their dependency on the _**Effect_Pack_FriendlyName**_ in the _mep_audio_component.inf_ file. A more robust approach would be to dynamically retrieve this information from the registry.

## How did you test the change?
Ran both CheckInTest and ReleaseTest across various silicon device.

## Related Issues (if any):

