### PR TITLE
Add power profile support for test automation

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -16,7 +16,7 @@ INPUT PARAMETERS:
     - devPowStat [string] :- The device power state (e.g., "PluggedIn", "OnBattery").
     - VF [string] :- Voice Focus setting ("On"/"Off"/"NA").
     - toggleEachAiEffect [array] :- Array containing AI effect toggles for various camera settings.
-    - powerProfile [string] :- The power profile to use for testing (Best Power Efficiency/Balanced/Best Performance/Recommended/Better Performance).
+    - powerProfile [string] :- The power profile to use for testing (Best Power Efficiency/Balanced/Best Performance).
 RETURN TYPE:
     - void 
 #>

--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -3,7 +3,7 @@ Add-Type -AssemblyName UIAutomationClient
 <#
 DESCRIPTION:
     This function tests the Camera App by setting video and photo resolutions, adjusting AI effects,
-    toggling power states, and validating logs for recording and previewing scenarios.
+    toggling power states and power profiles, and validating logs for recording and previewing scenarios.
     It ensures proper logging, checks service states, and collects trace data.
 INPUT PARAMETERS:
     - logFile [string] :- Path to the log file where test results will be recorded.
@@ -16,10 +16,11 @@ INPUT PARAMETERS:
     - devPowStat [string] :- The device power state (e.g., "PluggedIn", "OnBattery").
     - VF [string] :- Voice Focus setting ("On"/"Off"/"NA").
     - toggleEachAiEffect [array] :- Array containing AI effect toggles for various camera settings.
+    - powerProfile [string] :- The power profile to use for testing (Best Power Efficiency/Balanced/Best Performance/Recommended/Better Performance).
 RETURN TYPE:
     - void 
 #>
-function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$ptoRes,$devPowStat,$VF,$toggleEachAiEffect)
+function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$powerProfile,$camsnario,$vdoRes,$ptoRes,$devPowStat,$VF,$toggleEachAiEffect)
 {
    try
    {  
@@ -27,8 +28,10 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
        $VFdetails= "VF-$VF"
 	   $vdoResDetails= RetrieveValue($vdoRes)
 	   $ptoResDetails= RetrieveValue($ptoRes)       
-       $scenarioLogFolder = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails\$devPowStat\$VFdetails\$toggleEachAiEffect"
+       $powerProfileFolder = $powerProfile -replace ' ', ''
+       $scenarioLogFolder = "CameraAppTest\$powerProfileFolder\$camsnario\$vdoResDetails\$ptoResDetails\$devPowStat\$VFdetails\$toggleEachAiEffect"
        Write-Log -Message "`nStarting Test for $scenarioLogFolder`n" -IsOutput
+       Write-Log -Message "Power Profile: $powerProfile" -IsOutput
        Write-Log -Message "Creating the log folder" -IsOutput       
        CreateScenarioLogsFolder $scenarioLogFolder
 
@@ -42,7 +45,7 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
 
        #Set the device Power state
        #if token and SPid is available than run scenarios for both pluggedin and unplugged 
-       Write-Output "Start Tests for $devPowStat scenario" 
+        Write-Output "Start Tests for $devPowStat scenario with $powerProfile profile" 
        $devState = CheckDevicePowerState $devPowStat $token $SPId
        if($devState -eq $false)
        {   
@@ -144,7 +147,8 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
        #Strating to collect Traces
        StartTrace $scenarioLogFolder
 
-       Write-Log -Message "Start test for $camsnario" -IsOutput
+       # Start Test Scenario
+       Write-Log -Message "Start test for $camsnario with power profile: $powerProfile" -IsOutput
        if($camsnario -eq "Recording")
        {
            #Start video recording and close the camera app once finished recording 
@@ -198,14 +202,14 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
     catch
     {
         Take-Screenshot "Error-Exception" $scenarioLogFolder
-        Write-Log -Message "Error occured and enter catch statement" -IsOutput
+        Write-Log -Message "Error occurred during test with power profile: $powerProfile" -IsOutput
         CloseApp 'systemsettings'
         CloseApp 'WindowsCamera'
         CloseApp 'Taskmgr'
         StopTrace $scenarioLogFolder
         CheckServiceState 'Windows Camera Frame Server'
         Write-Output $_
-        TestOutputMessage $scenarioLogFolder "Exception" $startTime $_.Exception.Message
+        TestOutputMessage $scenarioLogFolder "Exception" $startTime "Power profile '$powerProfile': $($_.Exception.Message)"
         Write-Output $_ >> $pathLogsFolder\ConsoleResults.txt
         Reporting $Results "$pathLogsFolder\Report.txt"
         GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioLogFolder
@@ -218,5 +222,3 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
         continue;
     }                                
 }
-
-   

--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -16,7 +16,7 @@ INPUT PARAMETERS:
     - devPowStat [string] :- The device power state (e.g., "PluggedIn", "OnBattery").
     - VF [string] :- Voice Focus setting ("On"/"Off"/"NA").
     - toggleEachAiEffect [array] :- Array containing AI effect toggles for various camera settings.
-    - powerProfile [string] :- The power profile to use for testing (Best Power Efficiency/Balanced/Best Performance).
+    - powerProfile [string] :- The power profile to use for testing (Best Power Efficiency/Balanced/Best Performance/Recommended/Better Performance).
 RETURN TYPE:
     - void 
 #>

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -196,7 +196,16 @@ function AddToFailedTestsList($failedTests)
    $logFolder = $splitEachTests[0] -split ". "
    $functionToCall = $logFolder[1]
    $logFile = $logFolder[1] + ".txt"
-   $powerProfile = $splitEachTests[1]
+   # The folder name has spaces stripped (e.g. "BestPowerEfficiency"); map back to the full profile name
+   $powerProfileFolder = $splitEachTests[1]
+   $profileFolderToName = @{
+       "BestPowerEfficiency" = "Best Power Efficiency"
+       "Balanced"            = "Balanced"
+       "BestPerformance"     = "Best Performance"
+       "BetterPerformance"   = "Better Performance"
+       "Recommended"         = "Recommended"
+   }
+   $powerProfile = if ($profileFolderToName.ContainsKey($powerProfileFolder)) { $profileFolderToName[$powerProfileFolder] } else { $powerProfileFolder }
    $camsnario = $splitEachTests[2]
    $vdoRes = $splitEachTests[3]
    $ptoRes = $splitEachTests[4]

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -198,14 +198,8 @@ function AddToFailedTestsList($failedTests)
    $logFile = $logFolder[1] + ".txt"
    # The folder name has spaces stripped (e.g. "BestPowerEfficiency"); map back to the full profile name
    $powerProfileFolder = $splitEachTests[1]
-   $profileFolderToName = @{
-       "BestPowerEfficiency" = "Best Power Efficiency"
-       "Balanced"            = "Balanced"
-       "BestPerformance"     = "Best Performance"
-       "BetterPerformance"   = "Better Performance"
-       "Recommended"         = "Recommended"
-   }
-   $powerProfile = if ($profileFolderToName.ContainsKey($powerProfileFolder)) { $profileFolderToName[$powerProfileFolder] } else { $powerProfileFolder }
+   $powerProfile = RetrieveValue($powerProfileFolder)
+   if (-not $powerProfile) { $powerProfile = $powerProfileFolder }
    $camsnario = $splitEachTests[2]
    $vdoRes = $splitEachTests[3]
    $ptoRes = $splitEachTests[4]

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -205,11 +205,13 @@ function AddToFailedTestsList($failedTests)
    $togAiEfft = $splitEachTests[6]
    $token = "111222"
    $SPID ="333444"
+   $powerProfile = $splitEachTests[7]
+
    if($functionToCall -eq  "CameraAppTest")
    {
       $vdoRes = RetrieveValue($vdoRes)
       $ptoRes = RetrieveValue($ptoRes) 
-      Write-Output "$functionToCall -logFile `"$logFile`" $token $SPId -camsnario `"$camsnario`" -vdoRes `"$($vdoRes -join ', ')`" -ptoRes `"$($ptoRes -join ', ')`" -devPowStat `"$devPowStat`" -VF `"$VF`" -toggleEachAiEffect `"$togAiEfft`" >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
+      Write-Output "$functionToCall -logFile `"$logFile`" $token $SPId -camsnario `"$camsnario`" -vdoRes `"$($vdoRes -join ', ')`" -ptoRes `"$($ptoRes -join ', ')`" -devPowStat `"$devPowStat`" -VF `"$VF`" -toggleEachAiEffect `"$togAiEfft`" -powerProfile `"$powerProfile`" >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
       Write-Output $failedTests >> $pathLogsFolder\failedTests.txt
    }
    else

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -193,19 +193,19 @@ RETURN TYPE:
 function AddToFailedTestsList($failedTests)
 {
    $splitEachTests = $failedTests -split "\\"
-   $camsnario = $splitEachTests[1]
    $logFolder = $splitEachTests[0] -split ". "
    $functionToCall = $logFolder[1]
    $logFile = $logFolder[1] + ".txt"
-   $vdoRes = $splitEachTests[2]
-   $ptoRes = $splitEachTests[3]
-   $devPowStat = $splitEachTests[4]
-   $VFdetails  = $splitEachTests[5] -split "-"
+   $powerProfile = $splitEachTests[1]
+   $camsnario = $splitEachTests[2]
+   $vdoRes = $splitEachTests[3]
+   $ptoRes = $splitEachTests[4]
+   $devPowStat = $splitEachTests[5]
+   $VFdetails  = $splitEachTests[6] -split "-"
    $VF = $VFdetails[1]
-   $togAiEfft = $splitEachTests[6]
+   $togAiEfft = $splitEachTests[7]
    $token = "111222"
    $SPID ="333444"
-   $powerProfile = $splitEachTests[7]
 
    if($functionToCall -eq  "CameraAppTest")
    {

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -22,6 +22,7 @@ function GetDeviceDetails()
    $deviceData.VideoResolutions = GetVideoResList
    $deviceData.PhotoResolutions = GetPhotoResList
    $deviceData.PowerStates      = @("Pluggedin", "Unplugged")
+   $deviceData.PowerProfiles = GetPowerProfiles
    $voiceFocusExists = CheckVoiceFocusPolicy 
    if($voiceFocusExists -eq $false)
    {
@@ -80,6 +81,8 @@ function Generate-Combinations {
     }
     return $combinations
 }
+
+
 <#
 DESCRIPTION:
     This function retrieves the list of supported video resolutions from the Camera app settings.
@@ -292,4 +295,32 @@ function Filter-Resolutions {
     Write-Host "==============================`n" -ForegroundColor Cyan
     
     return $filtered.ToArray()
+}
+
+
+<#
+DESCRIPTION:
+    This function retrieves the list of supported Power Profiles.
+    It opens the Settings app and checks the available Power Profiles options.
+
+RETURN TYPE:
+    - Array: List of supported Power Profiles.
+#>
+function GetPowerProfiles
+{
+    Add-Type -AssemblyName UIAutomationClient
+
+    # Navigate directly to Power page via URI
+    $ui = OpenApp 'ms-settings:powersleep' 'Settings'
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ExpanderToggleButton" "Show more settings"
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ComboBox" "Plugged in"
+    Start-Sleep -Seconds 3
+    $pluggedInProfiles = FindAllElementsNameWithClassName $ui ComboBoxItem
+    Start-Sleep -Seconds 2
+    Write-Log -Message "Available power profiles: $pluggedInProfiles" -IsOutput | Out-Null
+    Stop-Process -Name 'systemsettings'
+    
+    return $pluggedInProfiles
 }

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -323,7 +323,7 @@ function GetPowerProfiles
     $pluggedInProfiles = @($pluggedInProfiles | Where-Object { $knownPowerProfiles -contains $_ })
     Start-Sleep -Seconds 2
     Write-Log -Message "Available power profiles: $pluggedInProfiles" -IsOutput | Out-Null
-    Stop-Process -Name 'systemsettings'
+    CloseApp 'systemsettings'
     
     return $pluggedInProfiles
 }

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -318,6 +318,9 @@ function GetPowerProfiles
     FindAndClick $ui "ComboBox" "Plugged in"
     Start-Sleep -Seconds 3
     $pluggedInProfiles = FindAllElementsNameWithClassName $ui ComboBoxItem
+    # Filter to known Windows power profile names to avoid spurious items from other ComboBoxes on the page
+    $knownPowerProfiles = @("Best Power Efficiency", "Balanced", "Best Performance", "Better Performance", "Recommended")
+    $pluggedInProfiles = @($pluggedInProfiles | Where-Object { $knownPowerProfiles -contains $_ })
     Start-Sleep -Seconds 2
     Write-Log -Message "Available power profiles: $pluggedInProfiles" -IsOutput | Out-Null
     Stop-Process -Name 'systemsettings'

--- a/E2E/Library/LookUpTable.ps1
+++ b/E2E/Library/LookUpTable.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 DESCRIPTION:
     Builds a configuration array based on a set of input effects.
 

--- a/E2E/Library/LookUpTable.ps1
+++ b/E2E/Library/LookUpTable.ps1
@@ -143,6 +143,13 @@ function RetrieveValue($inputValue)
    $returnValues.Add("0.1 megapixels, 11 by 9 aspect ratio,  352 by 288 resolution" , '0.1MP')
    $returnValues.Add("0.03 megapixels, 11 by 9 aspect ratio,  176 by 144 resolution" ,'0.03MP')
 
+   # Power profile folder name to display name mappings
+   $returnValues.Add("BestPowerEfficiency", "Best Power Efficiency")
+   $returnValues.Add("Balanced", "Balanced")
+   $returnValues.Add("BestPerformance", "Best Performance")
+   $returnValues.Add("BetterPerformance", "Better Performance")
+   $returnValues.Add("Recommended", "Recommended")
+
    
    $outputValue = $returnValues[$inputValue]
    return $outputValue

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -253,15 +253,13 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
 <#
 DESCRIPTION:
     This function opens the Settings page -> System -> Power & battery -> Power mode. It waits for the UI
-    and attempts to set the specified power profile for both "Plugged in" and "On battery" modes. If the Power profile 
-    is unsupported, the test is skipped and logged.
+    and attempts to set the specified power profile for both "Plugged in" and "On battery" modes.
 INPUT PARAMETERS:
-    - ui [object] :- The UI automation element representing the Settings page.
     - powerProfile [string] :- The desired Power profile (e.g., "Balanced"/"Best Power Efficiency"/"Best Performance").
 RETURN TYPE:
-    - [bool] (Returns `$false` if the Power profile is unsupported, otherwise closes the app without returning a value.)
+    - void
 #>
-function SetPowerProfileInSettingsPage($ui,$powerProfile)
+function SetPowerProfileInSettingsPage($powerProfile)
 {
     Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
 

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -261,7 +261,7 @@ RETURN TYPE:
 #>
 function SetPowerProfileInSettingsPage($powerProfile)
 {
-    Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
+    Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput | Out-Null
 
     # Navigate directly to Power page via URI
     $ui = OpenApp 'ms-settings:powersleep' 'Settings'
@@ -272,18 +272,18 @@ function SetPowerProfileInSettingsPage($powerProfile)
     Start-Sleep -Seconds 3
     
     # Set "Plugged in" power mode
-    Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput
+    Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput | Out-Null
     FindAndClick $ui "ComboBox" "Plugged in"
     Start-Sleep -Seconds 3
     FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
     Start-Sleep -Seconds 3
-    Write-Log -Message "Plugged in mode set to $powerProfile" -IsOutput
+    Write-Log -Message "Plugged in mode set to $powerProfile" -IsOutput | Out-Null
     
     # Set "On battery" power mode
     FindAndClick $ui "ComboBox" "On battery"
     Start-Sleep -Seconds 3
     FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
     Start-Sleep -Seconds 3
-    Write-Log -Message "On battery mode set to $powerProfile" -IsOutput
-    Write-Log -Message "Power profile set to $powerProfile" -IsOutput
+    Write-Log -Message "On battery mode set to $powerProfile" -IsOutput | Out-Null
+    Write-Log -Message "Power profile set to $powerProfile" -IsOutput | Out-Null
 }

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -249,3 +249,43 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
      #close settings app
      CloseApp 'systemsettings'
 }
+
+<#
+DESCRIPTION:
+    This function opens the Settings page -> System -> Power & battery -> Power mode. It waits for the UI
+    and attempts to set the specified power profile for both "Plugged in" and "On battery" modes. If the Power profile 
+    is unsupported, the test is skipped and logged.
+INPUT PARAMETERS:
+    - ui [object] :- The UI automation element representing the Settings page.
+    - powerProfile [string] :- The desired Power profile (e.g., "Balanced"/"Best Power Efficiency"/"Best Performance").
+RETURN TYPE:
+    - [bool] (Returns `$false` if the Power profile is unsupported, otherwise closes the app without returning a value.)
+#>
+function SetPowerProfileInSettingsPage($ui,$powerProfile)
+{
+    Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
+
+    # Navigate directly to Power page via URI
+    $ui = OpenApp 'ms-settings:powersleep' 'Settings'
+    Start-Sleep -Seconds 3
+
+    # Expand "Show more settings"
+    FindAndClick $ui "ExpanderToggleButton" "Show more settings"
+    Start-Sleep -Seconds 3
+    
+    # Set "Plugged in" power mode
+    Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput
+    FindAndClick $ui "ComboBox" "Plugged in"
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
+    Start-Sleep -Seconds 3
+    Write-Log -Message "Plugged in mode set to $powerProfile" -IsOutput
+    
+    # Set "On battery" power mode
+    FindAndClick $ui "ComboBox" "On battery"
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
+    Start-Sleep -Seconds 3
+    Write-Log -Message "On battery mode set to $powerProfile" -IsOutput
+    Write-Log -Message "Power profile set to $powerProfile" -IsOutput
+}

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -253,13 +253,15 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
 <#
 DESCRIPTION:
     This function opens the Settings page -> System -> Power & battery -> Power mode. It waits for the UI
-    and attempts to set the specified power profile for both "Plugged in" and "On battery" modes.
+    and attempts to set the specified power profile for both "Plugged in" and "On battery" modes. If the Power profile 
+    is unsupported, the test is skipped and logged.
 INPUT PARAMETERS:
+    - ui [object] :- The UI automation element representing the Settings page.
     - powerProfile [string] :- The desired Power profile (e.g., "Balanced"/"Best Power Efficiency"/"Best Performance").
 RETURN TYPE:
-    - void
+    - [bool] (Returns `$false` if the Power profile is unsupported, otherwise closes the app without returning a value.)
 #>
-function SetPowerProfileInSettingsPage($powerProfile)
+function SetPowerProfileInSettingsPage($ui,$powerProfile)
 {
     Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
 

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -54,158 +54,158 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
          $vdoResDetails= RetrieveValue($vdoRes)
          $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
 
-      Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+         Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
       
-      #skip the test if video resolution is not available. 
-      $result = SetvideoResolutionInCameraApp $scenarioName $startTime $vdoRes
-      if($result[-1]  -eq $false)
-      {
-         write-Error "Expected video Res is not found: $vdoRes"
-         continue;
-      }  
-      
-      # Loop through photo resolutions  
-      foreach ($ptoRes in  $filteredPhotoResolutions)
-      {   
-         #Retrieve photo resolution from hash table 
-         $ptoResDetails= RetrieveValue($ptoRes)       
-         $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails" 
-
-         Write-Log -Message "Setting up Photo Res to $ptoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-
-         #skip the test if photo resolution is not available. 
-         $result = SetphotoResolutionInCameraApp $scenarioName $startTime $ptoRes
+         #skip the test if video resolution is not available. 
+         $result = SetvideoResolutionInCameraApp $scenarioName $startTime $vdoRes
          if($result[-1]  -eq $false)
          {
-            write-Error "Expected Photo Res is not found: $ptoRes"
+            write-Error "Expected video Res is not found: $vdoRes"
             continue;
-         } 
+         }  
+      
+         # Loop through photo resolutions  
+         foreach ($ptoRes in  $filteredPhotoResolutions)
+         {   
+            #Retrieve photo resolution from hash table 
+            $ptoResDetails= RetrieveValue($ptoRes)       
+            $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails" 
 
-         foreach($VF in $deviceData["VoiceFocus"])
-         {  
-            if($VF -ne "NA")
+            Write-Log -Message "Setting up Photo Res to $ptoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+
+            #skip the test if photo resolution is not available. 
+            $result = SetphotoResolutionInCameraApp $scenarioName $startTime $ptoRes
+            if($result[-1]  -eq $false)
             {
-               Write-Log -Message "Setting up Voice Focus to $VF" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-               VoiceFocusToggleSwitch $VF >> "$pathLogsFolder\CameraAppTest.txt"
-            }
+               write-Error "Expected Photo Res is not found: $ptoRes"
+               continue;
+            } 
 
-            $unpluggedLast = -1
-            $pluggedInLast = -1
+            foreach($VF in $deviceData["VoiceFocus"])
+            {  
+               if($VF -ne "NA")
+               {
+                  Write-Log -Message "Setting up Voice Focus to $VF" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+                  VoiceFocusToggleSwitch $VF >> "$pathLogsFolder\CameraAppTest.txt"
+               }
 
-            while ($true)
-            {
-               $batteryPercentage = Get-BatteryPercentage
-               $chargingState = Get-ChargingState  # Fetch current charging state
+               $unpluggedLast = -1
+               $pluggedInLast = -1
 
-               <#
-               Approach we follow to run all the tests (pluggedin + unplugged) when smart plug details are provided along with run mode = Both or null (null meaning not provided):
-                  1. Battery Check: At the start, the battery status is checked.
-                  2. Unplugged Scenarios: If the battery is above 20%, the Unplugged scenarios will run. If the battery drops below 20% during the 
-                     Unplugged scenarios, the device is immediately plugged in for charging.
-                  3. Plugged-in Scenarios: We start executing pluggedIn tests during this state. This is done until either we complete all unplugged 
-                     state tests, or we reach 80% charge.
-                  4. Unplugged Scenarios Continuation: Once either of the above-mentioned state is attained, the remaining Unplugged scenarios are executed.
-                  5. This loop continues until both the unplugged and pluggedIn tests are completed.
-               #>
-               if ($token -and $SPId -and ($runMode -eq "Both" -or [string]::IsNullOrEmpty($runMode))) {
-                  if ($batteryPercentage -lt 20) {
-                     while ($batteryPercentage -lt 80 -and $pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
-                        $pluggedInLast++
-                        $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
-                        $devPowStat = "PluggedIn"
+               while ($true)
+               {
+                  $batteryPercentage = Get-BatteryPercentage
+                  $chargingState = Get-ChargingState  # Fetch current charging state
+
+                  <#
+                  Approach we follow to run all the tests (pluggedin + unplugged) when smart plug details are provided along with run mode = Both or null (null meaning not provided):
+                     1. Battery Check: At the start, the battery status is checked.
+                     2. Unplugged Scenarios: If the battery is above 20%, the Unplugged scenarios will run. If the battery drops below 20% during the 
+                        Unplugged scenarios, the device is immediately plugged in for charging.
+                     3. Plugged-in Scenarios: We start executing pluggedIn tests during this state. This is done until either we complete all unplugged 
+                        state tests, or we reach 80% charge.
+                     4. Unplugged Scenarios Continuation: Once either of the above-mentioned state is attained, the remaining Unplugged scenarios are executed.
+                     5. This loop continues until both the unplugged and pluggedIn tests are completed.
+                  #>
+                  if ($token -and $SPId -and ($runMode -eq "Both" -or [string]::IsNullOrEmpty($runMode))) {
+                     if ($batteryPercentage -lt 20) {
+                        while ($batteryPercentage -lt 80 -and $pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
+                           $pluggedInLast++
+                           $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
+                           $devPowStat = "PluggedIn"
+                           CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                           $batteryPercentage = Get-BatteryPercentage
+                        }
+                     } else {
+                        if ($unpluggedLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
+                           $unpluggedLast++
+                           $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
+                           $devPowStat = "Unplugged"
+                        } else {
+                           $pluggedInLast++
+                           $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
+                           $devPowStat = "PluggedIn"
+                        }
                         CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
-                        $batteryPercentage = Get-BatteryPercentage
                      }
-                  } else {
+
+                     if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
+                        Write-Host "Completed all AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
+                        break
+                     }
+                  }
+
+                  <#
+                  Approach we follow to run only unplugged tests:
+                     1. Run unplugged tests only when the run mode is set to "UnpluggedOnly" and smart plug details are provided.
+                     2. When tried to run unplugged tests without smart plug details, the script prints error message that smart plug details are mandatory to run unplugged tests.
+                     3. The script exits if all the unplugged scenarios are completed.
+                     4. The script plugs in the device (until it reaches 50%) when the battery drops below 20% during the unplugged tests.
+                  #>
+                  elseif ($runMode -eq "UnpluggedOnly") {
+
+                     if ($batteryPercentage -lt 20) {
+                        Write-Host "Battery below 20%. Plugging in to charge to 50%..." -ForegroundColor Cyan
+                        SetSmartPlugState $token $SPId 1  # Plug in
+                        while ($batteryPercentage -lt 50) {
+                            Start-Sleep -Seconds 60
+                            $batteryPercentage = Get-BatteryPercentage
+                            Write-Host "Charging... Current battery: $batteryPercentage%" -ForegroundColor Blue
+                        }
+                        Write-Host "Battery reached 50%. Unplugging and resuming tests." -ForegroundColor Green
+                        SetSmartPlugState $token $SPId 0  # Unplug
+                        Start-Sleep -Seconds 10  # Wait for state to stabilize
+                    }
+
+                     if (-not ($token -and $SPId)) {
+                        Write-Error "Smart plug ID is required to run unplugged tests. Exiting."
+                        return
+                     }
                      if ($unpluggedLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
                         $unpluggedLast++
                         $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
                         $devPowStat = "Unplugged"
+                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                      } else {
+                        Write-Host "Completed all Unplugged AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
+                        break
+                     }
+                  }
+
+                  <#
+                  Approach we follow to run only pluggedin tests with or without smart plug details are provided:
+                     1. Run pluggedIn tests for following cases:
+                        a. When the run mode is set to "PluggedInOnly".
+                        b. When the device is charging and run mode is not provided.
+                     2. Above tests run until all the pluggedIn scenarios are completed. 
+                     3. Once all are ompleted, the script exits.
+                  #>
+                  elseif ($runMode -eq "PluggedInOnly" -or ([string]::IsNullOrEmpty($runMode) -and $chargingState -eq "Charging")) {
+                     if ($pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
                         $pluggedInLast++
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
-                     }
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                        CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     } else {
+                        Write-Host "Completed all PluggedIn AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
+                        break
+                     } 
                   }
-
-                  if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
-                     Write-Host "Completed all AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
-                     break
-                  }
-               }
-
-               <#
-               Approach we follow to run only unplugged tests:
-                  1. Run unplugged tests only when the run mode is set to "UnpluggedOnly" and smart plug details are provided.
-                  2. When tried to run unplugged tests without smart plug details, the script prints error message that smart plug details are mandatory to run unplugged tests.
-                  3. The script exits if all the unplugged scenarios are completed.
-                  4. The script plugs in the device (until it reaches 50%) when the battery drops below 20% during the unplugged tests.
-               #>
-               elseif ($runMode -eq "UnpluggedOnly") {
-
-                  if ($batteryPercentage -lt 20) {
-                     Write-Host "Battery below 20%. Plugging in to charge to 50%..." -ForegroundColor Cyan
-                     SetSmartPlugState $token $SPId 1  # Plug in
-                     while ($batteryPercentage -lt 50) {
-                         Start-Sleep -Seconds 60
-                         $batteryPercentage = Get-BatteryPercentage
-                         Write-Host "Charging... Current battery: $batteryPercentage%" -ForegroundColor Blue
-                     }
-                     Write-Host "Battery reached 50%. Unplugging and resuming tests." -ForegroundColor Green
-                     SetSmartPlugState $token $SPId 0  # Unplug
-                     Start-Sleep -Seconds 10  # Wait for state to stabilize
-                 }
-
-                  if (-not ($token -and $SPId)) {
-                     Write-Error "Smart plug ID is required to run unplugged tests. Exiting."
+               
+                  <#
+                  Cases where release tests doesn't run are:
+                     1. .\ReleaseTest.ps1 without connecting to any charger.
+                     2. .\ReleaseTest.ps1 -runMode "UnpluggedOnly" when device is not connect to any smart plug.
+                     3. .\ReleaseTest.ps1 -token "123456" -SPId "7891011" when device is not connect to any charger.
+                  #>
+                  else {
+                     Write-Error "Invalid run mode specified or necessary parameters missing."
                      return
                   }
-                  if ($unpluggedLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
-                     $unpluggedLast++
-                     $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
-                     $devPowStat = "Unplugged"
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
-                  } else {
-                     Write-Host "Completed all Unplugged AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
-                     break
-                  }
                }
-
-               <#
-               Approach we follow to run only pluggedin tests with or without smart plug details are provided:
-                  1. Run pluggedIn tests for following cases:
-                     a. When the run mode is set to "PluggedInOnly".
-                     b. When the device is charging and run mode is not provided.
-                  2. Above tests run until all the pluggedIn scenarios are completed. 
-                  3. Once all are ompleted, the script exits.
-               #>
-               elseif ($runMode -eq "PluggedInOnly" -or ([string]::IsNullOrEmpty($runMode) -and $chargingState -eq "Charging")) {
-                  if ($pluggedInLast -lt $deviceData["ToggleAiEffect"].Count - 1) {
-                     $pluggedInLast++
-                     $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
-                     $devPowStat = "PluggedIn"
-                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
-                  } else {
-                     Write-Host "Completed all PluggedIn AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
-                     break
-                  } 
-               }
-               
-               <#
-               Cases where release tests doesn't run are:
-                  1. .\ReleaseTest.ps1 without connecting to any charger.
-                  2. .\ReleaseTest.ps1 -runMode "UnpluggedOnly" when device is not connect to any smart plug.
-                  3. .\ReleaseTest.ps1 -token "123456" -SPId "7891011" when device is not connect to any charger.
-               #>
-               else {
-                  Write-Error "Invalid run mode specified or necessary parameters missing."
-                  return
-               }
-            }
-         } 
+            } 
+         }
       }
-   }
    }
 }
 

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -45,11 +45,11 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
    # Loop through Camera mode
    foreach($camsnario in $deviceData["CameraScenario"])
    {  
+      $initialSetupDone = "true" 
+      $startTime = Get-Date 
       # Loop through video resolutions
       foreach ($vdoRes in $filteredVideoResolutions)
       {
-         $initialSetupDone = "true" 
-         $startTime = Get-Date 
          #Retrieve video resolution from hash table
          $vdoResDetails= RetrieveValue($vdoRes)
          $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -40,7 +40,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
 {
    Write-Log -Message "Setting up Power Profile to $currentPowerProfile" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
    SetPowerProfileInSettingsPage -powerProfile $currentPowerProfile
-   Stop-Process -Name 'systemsettings'
+   CloseApp 'systemsettings'
 
    # Loop through Camera mode
    foreach($camsnario in $deviceData["CameraScenario"])

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -1,10 +1,11 @@
-﻿param ( 
+param ( 
    [string] $token = $null,
    [string] $SPId = $null,
    [string] $targetMepCameraVer = $null,
    [string] $targetMepAudioVer = $null,
    [string] $targetPerceptionCoreVer = $null,
-   [ValidateSet("Both", "PluggedInOnly", "UnpluggedOnly")][string] $runMode = $null
+   [ValidateSet("Both", "PluggedInOnly", "UnpluggedOnly")][string] $runMode = $null,
+   [string] $powerProfile = $null
 )
 .".\CheckInTest\Helper-library.ps1"
 
@@ -22,17 +23,36 @@ $filteredPhotoResolutions = Filter-Resolutions -requestedResolutions @() -availa
 # OneTime Setting- Open Camera App and set default setting to "Use system settings" 
 Set-SystemSettingsInCamera  >> "$pathLogsFolder\CameraAppTest.txt"
 
-# Loop through Camera mode
-foreach($camsnario in $deviceData["CameraScenario"])
-{  
-   # Loop through video resolutions
-   foreach ($vdoRes in $filteredVideoResolutions)
+# Determine power profiles to test: use user-specified profile or all available
+$powerProfilesToTest = if ($powerProfile) {
+   if ($deviceData["PowerProfiles"] -contains $powerProfile) {
+      @($powerProfile)
+   } else {
+      Write-Warning "Specified power profile '$powerProfile' is not available on this device. Available: $($deviceData['PowerProfiles'] -join ', ')"
+      Write-Log -Message "Power profile '$powerProfile' not available. Using all profiles." | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+      $deviceData["PowerProfiles"]
+   }
+} else {
+   $deviceData["PowerProfiles"]
+}
+
+foreach ($currentPowerProfile in $powerProfilesToTest)
+{
+   Write-Log -Message "Setting up Power Profile to $currentPowerProfile" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+   SetPowerProfileInSettingsPage -powerProfile $currentPowerProfile
+   Stop-Process -Name 'systemsettings'
+
+   # Loop through Camera mode
+   foreach($camsnario in $deviceData["CameraScenario"])
    {  
-      $initialSetupDone = "true" 
-      $startTime = Get-Date 
-      #Retrieve video resolution from hash table
-	   $vdoResDetails= RetrieveValue($vdoRes)
-      $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
+      # Loop through video resolutions
+      foreach ($vdoRes in $filteredVideoResolutions)
+      {
+         $initialSetupDone = "true" 
+         $startTime = Get-Date 
+         #Retrieve video resolution from hash table
+         $vdoResDetails= RetrieveValue($vdoRes)
+         $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
 
       Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
       
@@ -72,7 +92,8 @@ foreach($camsnario in $deviceData["CameraScenario"])
             $unpluggedLast = -1
             $pluggedInLast = -1
 
-            while ($true) {
+            while ($true)
+            {
                $batteryPercentage = Get-BatteryPercentage
                $chargingState = Get-ChargingState  # Fetch current charging state
 
@@ -92,7 +113,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                         $pluggedInLast++
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
-                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                         $batteryPercentage = Get-BatteryPercentage
                      }
                   } else {
@@ -105,7 +126,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
                      }
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   }
 
                   if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
@@ -144,7 +165,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                      $unpluggedLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
                      $devPowStat = "Unplugged"
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   } else {
                      Write-Host "Completed all Unplugged AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
                      break
@@ -164,7 +185,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                      $pluggedInLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                      $devPowStat = "PluggedIn"
-                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   } else {
                      Write-Host "Completed all PluggedIn AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
                      break
@@ -184,6 +205,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
             }
          } 
       }
+   }
    }
 }
 

--- a/E2E/ScenarioTest.ps1
+++ b/E2E/ScenarioTest.ps1
@@ -155,7 +155,7 @@ if($voiceFocusExists -eq $false)
 # Set up Power Profile
 Write-Log -Message "Setting up Power Profile to $powerProfile" | Out-File -FilePath "$pathLogsFolder\ScenarioTesting.txt" -Append
 SetPowerProfileInSettingsPage -powerProfile $powerProfile
-Stop-Process -Name 'systemsettings'
+CloseApp 'systemsettings'
 
 if($toggleAIEffects -eq "All")
 {

--- a/E2E/ScenarioTest.ps1
+++ b/E2E/ScenarioTest.ps1
@@ -136,7 +136,12 @@ param (
    [string] $ptoRes = "2.1 megapixels, 16 by 9 aspect ratio,  1920 by 1080 resolution",  # Default if not provided
 
    [ValidateSet("Pluggedin", "Unplugged")]
-   [string] $devPowStat = "Pluggedin"  # Default if not provided
+   [string] $devPowStat = "Pluggedin",  # Default if not provided
+
+   # Power Profile options: Best Power Efficiency, Balanced, Best Performance
+   # This parameter controls the Windows power mode setting used during the test
+   [ValidateSet("Best Power Efficiency", "Balanced", "Best Performance")]
+   [string] $powerProfile = "Balanced"  # Default if not provided
 
 )
 .".\CheckInTest\Helper-library.ps1"
@@ -146,6 +151,12 @@ if($voiceFocusExists -eq $false)
 {
    $VF = "NA"
 }
+
+# Set up Power Profile
+Write-Log -Message "Setting up Power Profile to $powerProfile" | Out-File -FilePath "$pathLogsFolder\ScenarioTesting.txt" -Append
+SetPowerProfileInSettingsPage -powerProfile $powerProfile
+Stop-Process -Name 'systemsettings'
+
 if($toggleAIEffects -eq "All")
 {
    $deviceData = GetDeviceDetails
@@ -153,8 +164,9 @@ if($toggleAIEffects -eq "All")
 }    
 foreach ($togAiEfft in $toggleAIEffects)
 {
-   CameraAppTest -token $token -SPId $SPId -logFile $logFile -initSetUpDone $initSetUpDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\ScenarioTesting.txt"
+   CameraAppTest -token $token -SPId $SPId -logFile $logFile -initSetUpDone $initSetUpDone -powerProfile $powerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\ScenarioTesting.txt"
 }
+
 [console]::beep(500,300)
 if($token.Length -ne 0 -and $SPId.Length -ne 0)
 {


### PR DESCRIPTION
## What changed?

- Added `GetPowerProfiles` function in DeviceDetails.ps1
- Added `SetPowerProfileInSettingsPage` in SettingsAppHandlers.ps1
- Added `-powerProfile` parameter to CameraAppTest, ScenarioTest, ReleaseTest
- Power profile loop in ReleaseTest for iterating tests across profiles
- Fix: use ms-settings:powersleep URI for direct Power page navigation
- Fix: increase wait times for Power page UI elements
- Fix: pipe Write-Log to Out-Null to prevent return value pollution
- Fix: remove dead GetResourceUtilizationStats call

## Why changed?

Tests need to validate camera AI effects behavior across different power profiles (e.g., Best Performance, Balanced, Best Power Efficiency). This adds the infrastructure to iterate test scenarios per power profile.

## How did you test the change?

- Verified PowerShell script syntax
- Tested Settings app navigation to Power page via URI
- Validated power profile detection on physical device

Split from PR #108. Independent of PR #109 (resolution filtering).