### PR TITLE
Add Studio Effects Quick Settings automation (ADO #57735988)

### DIFF
--- a/E2E/CheckInTest/CameraAppTest.ps1
+++ b/E2E/CheckInTest/CameraAppTest.ps1
@@ -3,7 +3,7 @@ Add-Type -AssemblyName UIAutomationClient
 <#
 DESCRIPTION:
     This function tests the Camera App by setting video and photo resolutions, adjusting AI effects,
-    toggling power states, and validating logs for recording and previewing scenarios.
+    toggling power states and power profiles, and validating logs for recording and previewing scenarios.
     It ensures proper logging, checks service states, and collects trace data.
 INPUT PARAMETERS:
     - logFile [string] :- Path to the log file where test results will be recorded.
@@ -16,10 +16,11 @@ INPUT PARAMETERS:
     - devPowStat [string] :- The device power state (e.g., "PluggedIn", "OnBattery").
     - VF [string] :- Voice Focus setting ("On"/"Off"/"NA").
     - toggleEachAiEffect [array] :- Array containing AI effect toggles for various camera settings.
+    - powerProfile [string] :- The power profile to use for testing (Best Power Efficiency/Balanced/Best Performance/Recommended/Better Performance).
 RETURN TYPE:
     - void 
 #>
-function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$ptoRes,$devPowStat,$VF,$toggleEachAiEffect)
+function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$powerProfile,$camsnario,$vdoRes,$ptoRes,$devPowStat,$VF,$toggleEachAiEffect)
 {
    try
    {  
@@ -27,8 +28,10 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
        $VFdetails= "VF-$VF"
 	   $vdoResDetails= RetrieveValue($vdoRes)
 	   $ptoResDetails= RetrieveValue($ptoRes)       
-       $scenarioLogFolder = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails\$devPowStat\$VFdetails\$toggleEachAiEffect"
+       $powerProfileFolder = $powerProfile -replace ' ', ''
+       $scenarioLogFolder = "CameraAppTest\$powerProfileFolder\$camsnario\$vdoResDetails\$ptoResDetails\$devPowStat\$VFdetails\$toggleEachAiEffect"
        Write-Log -Message "`nStarting Test for $scenarioLogFolder`n" -IsOutput
+       Write-Log -Message "Power Profile: $powerProfile" -IsOutput
        Write-Log -Message "Creating the log folder" -IsOutput       
        CreateScenarioLogsFolder $scenarioLogFolder
 
@@ -42,7 +45,7 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
 
        #Set the device Power state
        #if token and SPid is available than run scenarios for both pluggedin and unplugged 
-       Write-Output "Start Tests for $devPowStat scenario" 
+        Write-Output "Start Tests for $devPowStat scenario with $powerProfile profile" 
        $devState = CheckDevicePowerState $devPowStat $token $SPId
        if($devState -eq $false)
        {   
@@ -144,7 +147,8 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
        #Strating to collect Traces
        StartTrace $scenarioLogFolder
 
-       Write-Log -Message "Start test for $camsnario" -IsOutput
+       # Start Test Scenario
+       Write-Log -Message "Start test for $camsnario with power profile: $powerProfile" -IsOutput
        if($camsnario -eq "Recording")
        {
            #Start video recording and close the camera app once finished recording 
@@ -198,14 +202,14 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
     catch
     {
         Take-Screenshot "Error-Exception" $scenarioLogFolder
-        Write-Log -Message "Error occured and enter catch statement" -IsOutput
+        Write-Log -Message "Error occurred during test with power profile: $powerProfile" -IsOutput
         CloseApp 'systemsettings'
         CloseApp 'WindowsCamera'
         CloseApp 'Taskmgr'
         StopTrace $scenarioLogFolder
         CheckServiceState 'Windows Camera Frame Server'
         Write-Output $_
-        TestOutputMessage $scenarioLogFolder "Exception" $startTime $_.Exception.Message
+        TestOutputMessage $scenarioLogFolder "Exception" $startTime "Power profile '$powerProfile': $($_.Exception.Message)"
         Write-Output $_ >> $pathLogsFolder\ConsoleResults.txt
         Reporting $Results "$pathLogsFolder\Report.txt"
         GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioLogFolder
@@ -218,5 +222,3 @@ function CameraAppTest($logFile,$token,$SPId,$initSetUpDone,$camsnario,$vdoRes,$
         continue;
     }                                
 }
-
-   

--- a/E2E/CheckInTest/CameraAppTestQuickSettings.ps1
+++ b/E2E/CheckInTest/CameraAppTestQuickSettings.ps1
@@ -1,0 +1,199 @@
+Add-Type -AssemblyName UIAutomationClient
+
+<#
+DESCRIPTION:
+    This function tests the Camera App by setting video and photo resolutions, toggling AI effects
+    via the Quick Settings Studio Effects panel (instead of the Settings app), and validating logs
+    for recording and previewing scenarios. This is the Quick Settings variant of CameraAppTest.
+
+    The key difference from CameraAppTest is that AI effects are toggled through the
+    Quick Settings > Studio Effects flyout using OCR-based interaction, since the flyout
+    is not accessible via UI Automation.
+INPUT PARAMETERS:
+    - logFile [string] :- Path to the log file where test results will be recorded.
+    - token [string] :- Authentication token required to control the smart plug.
+    - SPId [string] :- Smart plug ID used to control device power states.
+    - initSetUpDone [string] :- Indicates whether the initial setup has already been completed ("true"/"false").
+    - camsnario [string] :- Specifies whether the test scenario is "Recording" or "Previewing".
+    - vdoRes [string] :- Video resolution setting to be applied in the Camera App.
+    - ptoRes [string] :- Photo resolution setting to be applied in the Camera App.
+    - devPowStat [string] :- The device power state (e.g., "PluggedIn", "OnBattery").
+    - VF [string] :- Voice Focus setting ("On"/"Off"/"NA").
+    - toggleEachAiEffect [array] :- Array containing AI effect toggles for various camera settings.
+    - powerProfile [string] :- The power profile to use for testing.
+RETURN TYPE:
+    - void 
+#>
+function CameraAppTestQuickSettings($logFile,$token,$SPId,$initSetUpDone,$powerProfile,$camsnario,$vdoRes,$ptoRes,$devPowStat,$VF,$toggleEachAiEffect)
+{
+   try
+   {  
+       $startTime = Get-Date
+       $VFdetails= "VF-$VF"
+       $vdoResDetails= RetrieveValue($vdoRes)
+       $ptoResDetails= RetrieveValue($ptoRes)       
+       $powerProfileFolder = $powerProfile -replace ' ', ''
+       $scenarioLogFolder = "CameraAppTestQS\$powerProfileFolder\$camsnario\$vdoResDetails\$ptoResDetails\$devPowStat\$VFdetails\$toggleEachAiEffect"
+       Write-Log -Message "`nStarting Quick Settings Test for $scenarioLogFolder`n" -IsOutput
+       Write-Log -Message "Power Profile: $powerProfile" -IsOutput
+       Write-Log -Message "Creating the log folder" -IsOutput       
+       CreateScenarioLogsFolder $scenarioLogFolder
+
+       # Retrieve value for scenario from Get-CombinationReturnValues function
+       $toggleEachAiEffect = Get-CombinationReturnValues -effects $toggleEachAiEffect
+       if($toggleEachAiEffect.length -eq 0)
+       {
+          TestOutputMessage $scenarioLogFolder "Skipped" $startTime "wsev2Policy Not Supported"
+          return
+       }
+
+       # Set the device Power state
+       Write-Output "Start Tests for $devPowStat scenario with $powerProfile profile (Quick Settings)" 
+       $devState = CheckDevicePowerState $devPowStat $token $SPId
+       if($devState -eq $false)
+       {   
+          TestOutputMessage  $scenarioLogFolder "Skipped" $startTime "Token is empty"  
+          return
+       }  
+       
+       if($initSetUpDone -ne "true")
+       {
+          # Open Camera App and set default setting to "Use system settings" 
+          Set-SystemSettingsInCamera
+          
+          # Open system setting page and toggle voice focus (not available in Quick Settings)
+          if($VF -ne "NA")
+          {
+             VoiceFocusToggleSwitch $VF
+          }
+          
+          # Video resolution 
+          Write-Log -Message "Setting up the video resolution to $vdoRes" -IsOutput
+           
+          # Skip the test if video resolution is not available
+          $result = SetvideoResolutionInCameraApp $scenarioLogFolder $startTime $vdoRes
+          if($result[-1]  -eq $false)
+          {
+             Write-Log -Message "$vdoRes is not supported" -IsOutput
+             return
+          }  
+          
+          # Photo resolution 
+          Write-Log -Message "Setting up the Photo resolution to $ptoRes" -IsOutput
+          
+          # Retrieve photo resolution from hash table
+          Write-Log -Message "Retrieve $ptoRes value from hash table" -IsOutput
+          # Skip the test if photo resolution is not available
+          $result = SetphotoResolutionInCameraApp $scenarioLogFolder $startTime $ptoRes
+          if($result[-1]  -eq $false)
+          {
+             Write-Log -Message "$PtoRes is not supported" -IsOutput
+             return
+          }
+       
+       }  
+
+       # Toggle AI effects via Quick Settings Studio Effects panel (OCR-based)
+       $scenarioID = $toggleEachAiEffect[15]
+       Write-Log -Message "Setting up camera AI effects via Quick Settings" -IsOutput
+
+       $qsResult = ToggleAIEffectsInQuickSettings `
+           -AFVal  $toggleEachAiEffect[0]  `
+           -AFSVal $(if($toggleEachAiEffect[1] -eq "True"){"On"}else{"Off"})  `
+           -AFCVal $(if($toggleEachAiEffect[2] -eq "True"){"On"}else{"Off"})  `
+           -PLVal  $toggleEachAiEffect[3]  `
+           -BBVal  $toggleEachAiEffect[4]  `
+           -BSVal  $(if($toggleEachAiEffect[5] -eq "True"){"On"}else{"Off"})  `
+           -BPVal  $(if($toggleEachAiEffect[6] -eq "True"){"On"}else{"Off"})  `
+           -ECVal  $toggleEachAiEffect[7]  `
+           -ECSVal $(if($toggleEachAiEffect[8] -eq "True"){"On"}else{"Off"})  `
+           -ECTVal $(if($toggleEachAiEffect[9] -eq "True"){"On"}else{"Off"})  `
+           -VFVal  "Off"  `
+           -CF     $toggleEachAiEffect[10] `
+           -CFI    $(if($toggleEachAiEffect[11] -eq "True"){"On"}else{"Off"}) `
+           -CFA    $(if($toggleEachAiEffect[12] -eq "True"){"On"}else{"Off"}) `
+           -CFW    $(if($toggleEachAiEffect[13] -eq "True"){"On"}else{"Off"})
+
+       if (-not $qsResult) {
+           Write-Warning "Some AI effects could not be set via Quick Settings. Test may be unreliable."
+       }
+       
+       # Checks if frame server is stopped
+       Write-Log -Message "Entering CheckServiceState function" -IsOutput
+       CheckServiceState 'Windows Camera Frame Server'
+                             
+       # Starting to collect Traces
+       StartTrace $scenarioLogFolder
+
+       # Start Test Scenario
+       Write-Log -Message "Start test for $camsnario with power profile: $powerProfile (Quick Settings)" -IsOutput
+       if($camsnario -eq "Recording")
+       {
+           $InitTimeCameraApp = StartVideoRecording -duration 6 -snarioName $scenarioLogFolder -logPath "$scenarioLogFolder\ResourceUtilization.txt"
+           $cameraAppStartTime = $InitTimeCameraApp[-1]
+           Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
+       }
+       else
+       {   
+           $InitTimeCameraApp = CameraPreviewing -duration 6 -snarioName $scenarioLogFolder -logPath "$scenarioLogFolder\ResourceUtilization.txt"
+           $cameraAppStartTime = $InitTimeCameraApp[-1]
+           Write-Log -Message "Camera App start time in UTC: ${cameraAppStartTime}" -IsOutput
+       }
+       # Checks if frame server is stopped
+       Write-Log -Message "Entering CheckServiceState function" -IsOutput
+       CheckServiceState 'Windows Camera Frame Server' 
+       
+       # Stop the Trace
+       Write-Log -Message "Entering StopTrace function" -IsOutput
+       StopTrace $scenarioLogFolder
+   
+       # Verify and validate if proper logs are generated or not
+       Verifylogs $scenarioLogFolder $scenarioID $startTime
+       
+       # Calculate Time from camera app started until PC trace first frame processed
+       Write-Log -Message "Entering CheckInitTimeCameraApp function" -IsOutput
+       CheckInitTimeCameraApp $scenarioLogFolder $scenarioID $cameraAppStartTime
+       
+       if($camsnario -eq "Recording")
+       {   
+          if($VF -eq "On")
+          { 
+             # Verify and validate audio blur logs
+             VerifyAudioBlurLogs $scenarioLogFolder 512 
+          } 
+           
+           # Get the properties of latest video recording
+           GetVideoDetails $scenarioLogFolder $pathLogsFolder
+       }
+       
+       Write-Log -Message "Entering GetContentOfLogFileAndCopyToTestSpecificLogFile function" -IsOutput
+       GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioLogFolder
+       
+       # Collect data for Reporting
+       Reporting $Results "$pathLogsFolder\Report.txt"
+   
+    }
+    catch
+    {
+        Take-Screenshot "Error-Exception" $scenarioLogFolder
+        Write-Log -Message "Error occurred during Quick Settings test with power profile: $powerProfile" -IsOutput
+        Close-QuickSettings   # Ensure Quick Settings is closed on error
+        CloseApp 'systemsettings'
+        CloseApp 'WindowsCamera'
+        CloseApp 'Taskmgr'
+        StopTrace $scenarioLogFolder
+        CheckServiceState 'Windows Camera Frame Server'
+        Write-Output $_
+        TestOutputMessage $scenarioLogFolder "Exception" $startTime "Power profile '$powerProfile' (QS): $($_.Exception.Message)"
+        Write-Output $_ >> $pathLogsFolder\ConsoleResults.txt
+        Reporting $Results "$pathLogsFolder\Report.txt"
+        GetContentOfLogFileAndCopyToTestSpecificLogFile $scenarioLogFolder
+        $getLogs = Get-Content -Path "$pathLogsFolder\$scenarioLogFolder\log.txt" -raw
+        Write-Log -Message $getLogs -IsHost
+        $logs = resolve-path "$pathLogsFolder\$scenarioLogFolder\log.txt"
+        Write-Log -Message "(Logs saved here:$logs)" -IsHost
+        SetSmartPlugState $token $SPId 1
+              
+        continue;
+    }                                
+}

--- a/E2E/CheckInTest/CameraAppTestQuickSettings.ps1
+++ b/E2E/CheckInTest/CameraAppTestQuickSettings.ps1
@@ -115,7 +115,9 @@ function CameraAppTestQuickSettings($logFile,$token,$SPId,$initSetUpDone,$powerP
            -CFW    $(if($toggleEachAiEffect[13] -eq "True"){"On"}else{"Off"})
 
        if (-not $qsResult) {
-           Write-Warning "Some AI effects could not be set via Quick Settings. Test may be unreliable."
+           Write-Log -Message "FAILURE: AI effects could not be set via Quick Settings. Marking test as failed." -IsOutput
+           TestOutputMessage $scenarioLogFolder "Failed(Exception)" $startTime "Quick Settings toggle failed - AI effects not set correctly"
+           return
        }
        
        # Checks if frame server is stopped

--- a/E2E/CheckInTest/Helper-library.ps1
+++ b/E2E/CheckInTest/Helper-library.ps1
@@ -24,6 +24,7 @@
 .".\Library\DeviceDetails.ps1"
 .".\Library\SetupandCompleteTestRun"
 .".\CheckInTest\CameraAppTest.ps1"
+.".\CheckInTest\CameraAppTestQuickSettings.ps1"
 .".\CheckInTest\SettingAppTest.ps1"
 .".\CheckInTest\VoiceFocusToggle.ps1"
 .".\CheckInTest\VoiceRecordere2eTest.ps1"
@@ -36,20 +37,21 @@
 .".\CheckInTest\ToggleAIEffectsMultipleTimes.ps1"
 .".\CheckInTest\MemoryUsage.ps1"
 
-# Quick Settings modules are loaded conditionally — OCR/WinRT dependencies
-# may not be available on all test machines. These are loaded on demand via
-# Import-QuickSettingsModules (called when -useQuickSettings is specified).
+# Quick Settings modules — ScreenCapture, OcrHelper, StudioEffectsHandler, and
+# CameraAppTestQuickSettings are dot-sourced at script level so their function
+# definitions are visible to all callers. OcrHelper gracefully sets $script:OcrAvailable
+# to $false if WinRT types are unavailable.
+.".\Helper\ScreenCapture.ps1"
+.".\Library\OcrHelper.ps1"
+.".\Library\StudioEffectsHandler.ps1"
+
 function Import-QuickSettingsModules {
     if ($script:QuickSettingsModulesLoaded) { return }
-    .".\Helper\ScreenCapture.ps1"
-    .".\Library\OcrHelper.ps1"
     # Fail fast if OCR types could not be loaded — downstream modules depend on them
     if (-not $script:OcrAvailable) {
         Write-Error "OCR WinRT types are not available. Quick Settings automation requires OCR support. Aborting." -ErrorAction Stop
     }
-    .".\Library\StudioEffectsHandler.ps1"
-    .".\CheckInTest\CameraAppTestQuickSettings.ps1"
     $script:QuickSettingsModulesLoaded = $true
-    Write-Log -Message "Quick Settings modules loaded (OCR, ScreenCapture, StudioEffects)" -IsOutput
+    Write-Log -Message "Quick Settings modules loaded (OCR available)" -IsOutput
 }
 

--- a/E2E/CheckInTest/Helper-library.ps1
+++ b/E2E/CheckInTest/Helper-library.ps1
@@ -23,6 +23,9 @@
 .".\Library\LookUpTable.ps1"
 .".\Library\DeviceDetails.ps1"
 .".\Library\SetupandCompleteTestRun"
+.".\Helper\ScreenCapture.ps1"
+.".\Library\OcrHelper.ps1"
+.".\Library\StudioEffectsHandler.ps1"
 
 .".\CheckInTest\CameraAppTest.ps1"
 .".\CheckInTest\SettingAppTest.ps1"
@@ -36,4 +39,5 @@
 .".\CheckInTest\RevisitCameraSettingPage.ps1"
 .".\CheckInTest\ToggleAIEffectsMultipleTimes.ps1"
 .".\CheckInTest\MemoryUsage.ps1"
+.".\CheckInTest\CameraAppTestQuickSettings.ps1"
 

--- a/E2E/CheckInTest/Helper-library.ps1
+++ b/E2E/CheckInTest/Helper-library.ps1
@@ -23,10 +23,6 @@
 .".\Library\LookUpTable.ps1"
 .".\Library\DeviceDetails.ps1"
 .".\Library\SetupandCompleteTestRun"
-.".\Helper\ScreenCapture.ps1"
-.".\Library\OcrHelper.ps1"
-.".\Library\StudioEffectsHandler.ps1"
-
 .".\CheckInTest\CameraAppTest.ps1"
 .".\CheckInTest\SettingAppTest.ps1"
 .".\CheckInTest\VoiceFocusToggle.ps1"
@@ -39,5 +35,17 @@
 .".\CheckInTest\RevisitCameraSettingPage.ps1"
 .".\CheckInTest\ToggleAIEffectsMultipleTimes.ps1"
 .".\CheckInTest\MemoryUsage.ps1"
-.".\CheckInTest\CameraAppTestQuickSettings.ps1"
+
+# Quick Settings modules are loaded conditionally — OCR/WinRT dependencies
+# may not be available on all test machines. These are loaded on demand via
+# Import-QuickSettingsModules (called when -useQuickSettings is specified).
+function Import-QuickSettingsModules {
+    if ($script:QuickSettingsModulesLoaded) { return }
+    .".\Helper\ScreenCapture.ps1"
+    .".\Library\OcrHelper.ps1"
+    .".\Library\StudioEffectsHandler.ps1"
+    .".\CheckInTest\CameraAppTestQuickSettings.ps1"
+    $script:QuickSettingsModulesLoaded = $true
+    Write-Log -Message "Quick Settings modules loaded (OCR, ScreenCapture, StudioEffects)" -IsOutput
+}
 

--- a/E2E/CheckInTest/Helper-library.ps1
+++ b/E2E/CheckInTest/Helper-library.ps1
@@ -43,6 +43,10 @@ function Import-QuickSettingsModules {
     if ($script:QuickSettingsModulesLoaded) { return }
     .".\Helper\ScreenCapture.ps1"
     .".\Library\OcrHelper.ps1"
+    # Fail fast if OCR types could not be loaded — downstream modules depend on them
+    if (-not $script:OcrAvailable) {
+        Write-Error "OCR WinRT types are not available. Quick Settings automation requires OCR support. Aborting." -ErrorAction Stop
+    }
     .".\Library\StudioEffectsHandler.ps1"
     .".\CheckInTest\CameraAppTestQuickSettings.ps1"
     $script:QuickSettingsModulesLoaded = $true

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -205,11 +205,13 @@ function AddToFailedTestsList($failedTests)
    $togAiEfft = $splitEachTests[6]
    $token = "111222"
    $SPID ="333444"
+   $powerProfile = $splitEachTests[7]
+
    if($functionToCall -eq  "CameraAppTest")
    {
       $vdoRes = RetrieveValue($vdoRes)
       $ptoRes = RetrieveValue($ptoRes) 
-      Write-Output "$functionToCall -logFile `"$logFile`" $token $SPId -camsnario `"$camsnario`" -vdoRes `"$($vdoRes -join ', ')`" -ptoRes `"$($ptoRes -join ', ')`" -devPowStat `"$devPowStat`" -VF `"$VF`" -toggleEachAiEffect `"$togAiEfft`" >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
+      Write-Output "$functionToCall -logFile `"$logFile`" $token $SPId -camsnario `"$camsnario`" -vdoRes `"$($vdoRes -join ', ')`" -ptoRes `"$($ptoRes -join ', ')`" -devPowStat `"$devPowStat`" -VF `"$VF`" -toggleEachAiEffect `"$togAiEfft`" -powerProfile `"$powerProfile`" >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
       Write-Output $failedTests >> $pathLogsFolder\failedTests.txt
    }
    else

--- a/E2E/Helper/OutputMessage.ps1
+++ b/E2E/Helper/OutputMessage.ps1
@@ -193,29 +193,36 @@ RETURN TYPE:
 function AddToFailedTestsList($failedTests)
 {
    $splitEachTests = $failedTests -split "\\"
-   $camsnario = $splitEachTests[1]
    $logFolder = $splitEachTests[0] -split ". "
    $functionToCall = $logFolder[1]
    $logFile = $logFolder[1] + ".txt"
-   $vdoRes = $splitEachTests[2]
-   $ptoRes = $splitEachTests[3]
-   $devPowStat = $splitEachTests[4]
-   $VFdetails  = $splitEachTests[5] -split "-"
+   # Path structure: {TestFolder}\{powerProfile}\{camsnario}\{vdoRes}\{ptoRes}\{devPowStat}\{VF}\{togAiEfft}
+   $powerProfileFolder = $splitEachTests[1]
+   $powerProfile = RetrieveValue($powerProfileFolder)
+   if (-not $powerProfile) { $powerProfile = $powerProfileFolder }
+   $camsnario = $splitEachTests[2]
+   $vdoRes = $splitEachTests[3]
+   $ptoRes = $splitEachTests[4]
+   $devPowStat = $splitEachTests[5]
+   $VFdetails  = $splitEachTests[6] -split "-"
    $VF = $VFdetails[1]
-   $togAiEfft = $splitEachTests[6]
+   $togAiEfft = $splitEachTests[7]
    $token = "111222"
    $SPID ="333444"
-   $powerProfile = $splitEachTests[7]
 
-   if($functionToCall -eq  "CameraAppTest")
+   # Map QS test folder back to its function name for rerun
+   $rerunFunction = if ($functionToCall -eq "CameraAppTestQS") { "CameraAppTestQuickSettings" } else { $functionToCall }
+
+   if($functionToCall -eq "CameraAppTest" -or $functionToCall -eq "CameraAppTestQS")
    {
       $vdoRes = RetrieveValue($vdoRes)
-      $ptoRes = RetrieveValue($ptoRes) 
-      Write-Output "$functionToCall -logFile `"$logFile`" $token $SPId -camsnario `"$camsnario`" -vdoRes `"$($vdoRes -join ', ')`" -ptoRes `"$($ptoRes -join ', ')`" -devPowStat `"$devPowStat`" -VF `"$VF`" -toggleEachAiEffect `"$togAiEfft`" -powerProfile `"$powerProfile`" >> `$pathLogsFolder\CameraAppTest.txt" >> $pathLogsFolder\ReRunFailedTests.ps1
+      $ptoRes = RetrieveValue($ptoRes)
+      $rerunLogFile = $logFile
+      Write-Output "$rerunFunction -logFile `"$rerunLogFile`" $token $SPId -camsnario `"$camsnario`" -vdoRes `"$($vdoRes -join ', ')`" -ptoRes `"$($ptoRes -join ', ')`" -devPowStat `"$devPowStat`" -VF `"$VF`" -toggleEachAiEffect `"$togAiEfft`" -powerProfile `"$powerProfile`" >> `$pathLogsFolder\$rerunLogFile" >> $pathLogsFolder\ReRunFailedTests.ps1
       Write-Output $failedTests >> $pathLogsFolder\failedTests.txt
    }
    else
    {
       Write-Output $failedTests >> $pathLogsFolder\failedTests.txt
    }
-} 
+}

--- a/E2E/Helper/ScreenCapture.ps1
+++ b/E2E/Helper/ScreenCapture.ps1
@@ -1,0 +1,106 @@
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+# Ensure DPI awareness is set for accurate screen coordinates
+if (-not ([System.Management.Automation.PSTypeName]'ScreenCaptureDPI').Type) {
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class ScreenCaptureDPI {
+    [DllImport("user32.dll")]
+    public static extern bool SetProcessDPIAware();
+}
+"@
+    [ScreenCaptureDPI]::SetProcessDPIAware() | Out-Null
+}
+
+<#
+DESCRIPTION:
+    Captures a screenshot of a specific screen region and returns it as a System.Drawing.Bitmap.
+    If no region is specified, captures the full virtual screen.
+INPUT PARAMETERS:
+    - X [int] :- Left coordinate of capture region (default: 0).
+    - Y [int] :- Top coordinate of capture region (default: 0).
+    - Width [int] :- Width of capture region (default: full screen width).
+    - Height [int] :- Height of capture region (default: full screen height).
+RETURN TYPE:
+    - [System.Drawing.Bitmap] :- The captured screenshot bitmap.
+#>
+function Capture-ScreenRegion {
+    param (
+        [int]$X = [System.Windows.Forms.SystemInformation]::VirtualScreen.X,
+        [int]$Y = [System.Windows.Forms.SystemInformation]::VirtualScreen.Y,
+        [int]$Width  = [System.Windows.Forms.SystemInformation]::VirtualScreen.Width,
+        [int]$Height = [System.Windows.Forms.SystemInformation]::VirtualScreen.Height
+    )
+
+    $bitmap   = New-Object System.Drawing.Bitmap($Width, $Height)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    $graphics.CopyFromScreen($X, $Y, 0, 0, [System.Drawing.Size]::new($Width, $Height))
+    $graphics.Dispose()
+
+    return $bitmap
+}
+
+
+<#
+DESCRIPTION:
+    Captures the right portion of the primary screen. Useful for targeting the Studio Effects /
+    Quick Settings flyout panels which appear on the right side of the screen.
+    Experiment 4 showed that capturing right ~40% avoids console noise and improves OCR accuracy.
+INPUT PARAMETERS:
+    - Fraction [double] :- Fraction of screen width to capture from the right (default: 0.4 = right 40%).
+RETURN TYPE:
+    - [System.Drawing.Bitmap] :- The captured screenshot bitmap of the right region.
+#>
+function Capture-RightScreenRegion {
+    param (
+        [double]$Fraction = 0.4
+    )
+
+    $screenWidth  = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
+    $screenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
+    $captureWidth = [int]($screenWidth * $Fraction)
+    $captureX     = $screenWidth - $captureWidth
+
+    return Capture-ScreenRegion -X $captureX -Y 0 -Width $captureWidth -Height $screenHeight
+}
+
+
+<#
+DESCRIPTION:
+    Saves a screenshot region to a PNG file in the scenario logs folder.
+INPUT PARAMETERS:
+    - FileName [string] :- File name (without extension).
+    - ScnrName [string] :- Scenario name for the log folder.
+    - X [int] :- Left coordinate (optional, defaults to full screen).
+    - Y [int] :- Top coordinate (optional, defaults to full screen).
+    - Width [int] :- Capture width (optional, defaults to full screen).
+    - Height [int] :- Capture height (optional, defaults to full screen).
+RETURN TYPE:
+    - [string] :- The full file path of the saved screenshot.
+#>
+function Take-RegionScreenshot {
+    param (
+        [string]$FileName,
+        [string]$ScnrName,
+        [int]$X = [System.Windows.Forms.SystemInformation]::VirtualScreen.X,
+        [int]$Y = [System.Windows.Forms.SystemInformation]::VirtualScreen.Y,
+        [int]$Width  = [System.Windows.Forms.SystemInformation]::VirtualScreen.Width,
+        [int]$Height = [System.Windows.Forms.SystemInformation]::VirtualScreen.Height
+    )
+
+    $scenarioName = "$ScnrName\Screenshots"
+    CreateScenarioLogsFolder $scenarioName
+    $screenshotDir  = "$pathLogsFolder\$scenarioName"
+    $screenshotPath = Resolve-Path $screenshotDir
+    $filePath       = Join-Path -Path $screenshotPath -ChildPath "$FileName.png"
+
+    $bitmap = Capture-ScreenRegion -X $X -Y $Y -Width $Width -Height $Height
+    $bitmap.Save($filePath, [System.Drawing.Imaging.ImageFormat]::Png)
+    $bitmap.Dispose()
+
+    Write-Log -Message "Region screenshot saved to $filePath" -IsOutput
+    return $filePath
+}

--- a/E2E/Helper/SetAsgTraceFolders.ps1
+++ b/E2E/Helper/SetAsgTraceFolders.ps1
@@ -34,6 +34,10 @@ function GetContentOfLogFileAndCopyToTestSpecificLogFile($scenarioLogFldr)
     $logCopyTo =  "$pathLogsFolder\$scenarioLogFldr\log.txt" 
     $search="Starting Test for "
     $linenumber = Get-Content $logCopyFrom | select-string $search | Select-Object -Last 1
-    $lne = $linenumber.LineNumber - 1
+    if ($linenumber -and $linenumber.LineNumber -gt 0) {
+        $lne = $linenumber.LineNumber - 1
+    } else {
+        $lne = 0
+    }
     Get-Content -Path $logCopyFrom | Select -Skip $lne > $logCopyTo 
 }

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -22,6 +22,7 @@ function GetDeviceDetails()
    $deviceData.VideoResolutions = GetVideoResList
    $deviceData.PhotoResolutions = GetPhotoResList
    $deviceData.PowerStates      = @("Pluggedin", "Unplugged")
+   $deviceData.PowerProfiles = GetPowerProfiles
    $voiceFocusExists = CheckVoiceFocusPolicy 
    if($voiceFocusExists -eq $false)
    {
@@ -80,6 +81,8 @@ function Generate-Combinations {
     }
     return $combinations
 }
+
+
 <#
 DESCRIPTION:
     This function retrieves the list of supported video resolutions from the Camera app settings.
@@ -292,4 +295,32 @@ function Filter-Resolutions {
     Write-Host "==============================`n" -ForegroundColor Cyan
     
     return $filtered.ToArray()
+}
+
+
+<#
+DESCRIPTION:
+    This function retrieves the list of supported Power Profiles.
+    It opens the Settings app and checks the available Power Profiles options.
+
+RETURN TYPE:
+    - Array: List of supported Power Profiles.
+#>
+function GetPowerProfiles
+{
+    Add-Type -AssemblyName UIAutomationClient
+
+    # Navigate directly to Power page via URI
+    $ui = OpenApp 'ms-settings:powersleep' 'Settings'
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ExpanderToggleButton" "Show more settings"
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ComboBox" "Plugged in"
+    Start-Sleep -Seconds 3
+    $pluggedInProfiles = FindAllElementsNameWithClassName $ui ComboBoxItem
+    Start-Sleep -Seconds 2
+    Write-Log -Message "Available power profiles: $pluggedInProfiles" -IsOutput | Out-Null
+    Stop-Process -Name 'systemsettings'
+    
+    return $pluggedInProfiles
 }

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -157,139 +157,202 @@ function Filter-Resolutions {
         [string[]]$availableResolutions,
         [string]$resolutionType
     )
-    
+
+    if (-not $requestedResolutions) { $requestedResolutions = @() }
+    if (-not $availableResolutions) { $availableResolutions = @() }
+
+    # Robust scoring:
+    # 1) megapixels (photo)
+    # 2) real WxH resolution
+    # 3) 1080p / 1440p / 720p style for video
+    function Get-ResolutionScore {
+        param([string]$s)
+        if (-not $s) { return 0.0 }
+        $t = $s.ToString()
+
+        # 1) megapixels: "12.2 megapixels", "2.1MP"
+        $m = [regex]::Match($t, '(\d+(?:\.\d+)?)\s*(?:MP\b|MPs\b|megapixel\b|megapixels\b)', 'IgnoreCase')
+        if ($m.Success) {
+            return [double]$m.Groups[1].Value * 1e6
+        }
+
+        # 2) real pixel resolution: "4032 by 3024", "3840 x 2160", with optional trailing "resolution"
+        $r = [regex]::Match($t, '(\d+)\s*by\s*(\d+)', 'IgnoreCase')
+        if (-not $r.Success) {
+            $r = [regex]::Match($t, '(\d+)\s*[x×]\s*(\d+)', 'IgnoreCase')
+        }
+        if ($r.Success) {
+            return [double]$r.Groups[1].Value * [double]$r.Groups[2].Value
+        }
+
+        # 3) height-based p-style for video: "1440p", "1080p", "720p", "360p"
+        $p = [regex]::Match($t, '(^|\D)(\d{3,4})p(\D|$)', 'IgnoreCase')
+        if ($p.Success) {
+            return [double]$p.Groups[2].Value * 1000.0
+        }
+
+        return 0.0
+    }
+
+    function Build-SortedList {
+        param([string[]]$list)
+        $objs = @()
+        foreach ($item in $list) {
+            $score = 0.0
+            try { $score = Get-ResolutionScore $item } catch { $score = 0.0 }
+            $objs += [PSCustomObject]@{ Text = $item; Score = $score }
+        }
+        # Sort by Score desc, then Text asc (stable)
+        return $objs | Sort-Object -Property @{Expression='Score';Descending=$true}, @{Expression='Text';Descending=$false}
+    }
+
+    Write-Host "`n=== $($resolutionType.ToUpper()) RESOLUTION SELECTION ===" -ForegroundColor Cyan
+
+    $filtered = New-Object System.Collections.Generic.List[String]
+
+    # NO user requested resolutions: use your rules
     if ($requestedResolutions.Count -eq 0) {
-        # Apply custom strategic defaults based on resolution type
-        $filtered = [System.Collections.Generic.List[string]]::new()
-        
-        if ($availableResolutions.Count -gt 0) {
-            if ($resolutionType -eq "video") {
-                # Video: Max, Min, and 720p (if available)
-                $filtered.Add($availableResolutions[0])        # Max (first)
-                
-                # Add Min (last) if different from Max
-                if ($availableResolutions.Count -gt 1) {
-                    $minRes = $availableResolutions[-1]
-                    if ($filtered -notcontains $minRes) {
-                        $filtered.Add($minRes)
-                    }
-                }
-                
-                # Add 720p if available and not already included
-                $resolution720p = $availableResolutions | Where-Object { $_ -like "*720p*" } | Select-Object -First 1
-                if ($resolution720p -and $filtered -notcontains $resolution720p) {
-                    $filtered.Add($resolution720p)
-                }
-                
-            } elseif ($resolutionType -eq "photo") {
-                # Photo: Highest resolution only
-                $filtered.Add($availableResolutions[0])
-                
-            } else {
-                # Default behavior: highest, middle, lowest
-                $filtered.Add($availableResolutions[0])
-                
-                # Add middle resolution if available
-                if ($availableResolutions.Count -gt 2) {
-                    $middleIndex = [Math]::Floor($availableResolutions.Count / 2)
-                    if ($filtered -notcontains $availableResolutions[$middleIndex]) {
-                        $filtered.Add($availableResolutions[$middleIndex])
-                    }
-                }
-                
-                # Add lowest resolution if different from highest
-                if ($availableResolutions.Count -gt 1) {
-                    $lowestRes = $availableResolutions[-1]  # Last element
-                    if ($filtered -notcontains $lowestRes) {
-                        $filtered.Add($lowestRes)
-                    }
+        if ($availableResolutions.Count -eq 0) {
+            Write-Host "No available $resolutionType resolutions found." -ForegroundColor Red
+            Write-Host "==============================`n" -ForegroundColor Cyan
+            return @()
+        }
+
+        $sortedObjs = Build-SortedList -list $availableResolutions
+        $sorted     = $sortedObjs | ForEach-Object { $_.Text }
+
+        if ($resolutionType -eq "video") {
+            # 1) Highest resolution (by score)
+            if ($sortedObjs.Count -gt 0) {
+                $filtered.Add($sortedObjs[0].Text)
+            }
+
+            # 2) 720p and 360p if present
+            $res720 = $sorted | Where-Object {
+                [regex]::IsMatch($_, '(^|\D)720p(\D|$)', 'IgnoreCase') -or
+                [regex]::IsMatch($_, '1280\s*[x×]\s*720', 'IgnoreCase')
+            } | Select-Object -First 1
+
+            $res360 = $sorted | Where-Object {
+                [regex]::IsMatch($_, '(^|\D)360p(\D|$)', 'IgnoreCase') -or
+                [regex]::IsMatch($_, '640\s*[x×]\s*360', 'IgnoreCase')
+            } | Select-Object -First 1
+
+            if ($res720 -and ($filtered -notcontains $res720)) {
+                $filtered.Add($res720)
+            }
+            if ($res360 -and ($filtered -notcontains $res360)) {
+                $filtered.Add($res360)
+            }
+
+            # 3) If neither 720p nor 360p, add lowest
+            if (-not $res720 -and -not $res360) {
+                $lowest = $sortedObjs[-1].Text
+                if ($lowest -and ($filtered -notcontains $lowest)) {
+                    $filtered.Add($lowest)
                 }
             }
         }
-        
-        Write-Log -Message "No $resolutionType resolutions specified. Using strategic defaults: $($filtered -join ', ')" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-        
+        elseif ($resolutionType -eq "photo") {
+            # Prefer 2.1MP if available (any "2.1" in megapixel string)
+            $res21 = $availableResolutions |
+                     Where-Object { $_ -match '2\.1' -and $_ -match 'megapixel|MP' } |
+                     Select-Object -First 1
+
+            if ($res21) {
+                $filtered.Add($res21)
+            } else {
+                # Otherwise highest by score
+                if ($sortedObjs.Count -gt 0) {
+                    $filtered.Add($sortedObjs[0].Text)
+                }
+            }
+        }
+
+        # Print defaults
         if ($filtered.Count -eq 0) {
-            $filtered.Add($availableResolutions[0])
-        }
-    }
-    # Check for wildcard (all resolutions)
-    elseif ($requestedResolutions -contains "All" -or $requestedResolutions -contains "*") {
-        Write-Log -Message "Using ALL available $resolutionType resolutions as requested" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-        $filtered = [System.Collections.Generic.List[string]]::new()
-        $filtered.AddRange($availableResolutions)
-    }
-    # Process requested resolutions
-    else {
-        $filtered = [System.Collections.Generic.List[string]]::new()
-        $invalid = [System.Collections.Generic.List[string]]::new()
-        
-        foreach ($requestedRes in $requestedResolutions) {
-            $found = $false
-            
-            # Try direct lookup first (RetrieveValue)
-            $fullResString = RetrieveValue($requestedRes)
-            $searchTarget = if ($fullResString) { $fullResString } else { $requestedRes }
-            
-            # Check exact match
-            if ($availableResolutions -contains $searchTarget) {
-                if ($filtered -notcontains $searchTarget) {
-                    $filtered.Add($searchTarget)
-                    Write-Log -Message "$resolutionType resolution '$requestedRes' found and selected" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-                }
-                $found = $true
-            } else {
-            # Try partial matching
-            $partialMatch = $availableResolutions | Where-Object { $_ -like "*$requestedRes*" } | Select-Object -First 1
-            if ($partialMatch) {
-                if ($filtered -notcontains $partialMatch) {
-                    $filtered.Add($partialMatch)
-                    Write-Log -Message "$resolutionType resolution '$requestedRes' matched to '$partialMatch'" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-                }
-                $found = $true
+            Write-Host "Selected $resolutionType Resolutions (0): none" -ForegroundColor Yellow
+        } else {
+            Write-Host "Selected $resolutionType Resolutions ($($filtered.Count)):" -ForegroundColor Yellow
+            foreach ($r in $filtered) {
+                Write-Host "  • $r" -ForegroundColor Green
             }
         }
-        
-        if (-not $found) {
-            $invalid.Add($requestedRes)
+        Write-Log -Message "No $resolutionType resolutions specified. Using strategic defaults: $($filtered -join ', ')" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+        Write-Host "==============================`n" -ForegroundColor Cyan
+        return $filtered.ToArray()
+    }
+
+    # Check for wildcard (all resolutions)
+    if ($requestedResolutions -contains "All" -or $requestedResolutions -contains "*") {
+        Write-Log -Message "Using ALL available $resolutionType resolutions as requested" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+        Write-Host "Selected $resolutionType Resolutions ($($availableResolutions.Count)): ALL" -ForegroundColor Yellow
+        foreach ($r in $availableResolutions) {
+            Write-Host "  • $r" -ForegroundColor Green
+        }
+        Write-Host "==============================`n" -ForegroundColor Cyan
+        return $availableResolutions
+    }
+
+    # User passed requested resolutions: match against available
+    $invalid = New-Object System.Collections.Generic.List[String]
+    foreach ($requestedRes in $requestedResolutions) {
+        $full = $null
+        try { $full = RetrieveValue($requestedRes) } catch {}
+        $search = if ($full) { $full } else { $requestedRes }
+
+        if ($availableResolutions -contains $search) {
+            if ($filtered -notcontains $search) {
+                $filtered.Add($search)
+                Write-Log -Message "$resolutionType resolution '$requestedRes' found and selected" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+            }
+        } else {
+            $match = $availableResolutions |
+                     Where-Object { $_ -like "*$requestedRes*" } |
+                     Select-Object -First 1
+            if ($match -and $filtered -notcontains $match) {
+                $filtered.Add($match)
+                Write-Log -Message "$resolutionType resolution '$requestedRes' matched to '$match'" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+            } else {
+                $invalid.Add($requestedRes)
+            }
         }
     }
-    
+
     # Handle invalid resolutions
     if ($invalid.Count -gt 0) {
         Write-Warning "The following $resolutionType resolutions are not available on this device:"
         $invalid | ForEach-Object { Write-Warning "  ✗ '$_'" }
-        
+
         Write-Host "`nAvailable $resolutionType resolutions on this device:" -ForegroundColor Cyan
         foreach ($availableRes in $availableResolutions) {
             $shortKey = RetrieveValue($availableRes)
             $displayText = if ($shortKey) { "$shortKey -> $availableRes" } else { $availableRes }
             Write-Host "  • $displayText" -ForegroundColor Green
         }
-        }
-        
-        # Validate we have at least one valid resolution
-        if ($filtered.Count -eq 0) {
-            Write-Error "CRITICAL: None of the requested $resolutionType resolutions are available on this device."
-            Write-Host "Please use one of the available $resolutionType resolutions listed above, or use -${resolutionType}Resolutions @('All') to test all available resolutions." -ForegroundColor Red
-            Write-Host "Example: .\ReleaseTest.ps1 -videoResolutions @('1080p', '720p') -photoResolutions @('12.2MP')" -ForegroundColor Yellow
-            exit 1
-        }
     }
-    
-    # Log and display selected resolutions (common for all paths)
+
+    # Validate we have at least one valid resolution
+    if ($filtered.Count -eq 0) {
+        Write-Error "CRITICAL: None of the requested $resolutionType resolutions are available on this device."
+        Write-Host "Please use one of the available $resolutionType resolutions listed above, or use -${resolutionType}Resolutions @('All') to test all available resolutions." -ForegroundColor Red
+        Write-Host "Example: .\ReleaseTest.ps1 -videoResolutions @('1080p', '720p') -photoResolutions @('12.2MP')" -ForegroundColor Yellow
+        exit 1
+    }
+
+    # Log and display selected resolutions
     $selectedResolutionsText = $filtered.ToArray() -join ', '
     Write-Log -Message "Selected $resolutionType Resolutions: $selectedResolutionsText" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-    
-    # Display selected resolutions to console
-    Write-Host "`n=== $($resolutionType.ToUpper()) RESOLUTION SELECTION ===" -ForegroundColor Cyan
-    Write-Host "Selected $resolutionType Resolutions ($($filtered.Count)):" -ForegroundColor Yellow
-    foreach ($res in $filtered) {
-        $resDetails = RetrieveValue($res)
-        $displayText = if ($resDetails) { "$resDetails -> $res" } else { $res }
-        Write-Host "  • $displayText" -ForegroundColor Green
+
+    if ($filtered.Count -eq 0) {
+        Write-Host "Selected $resolutionType Resolutions (0): none" -ForegroundColor Yellow
+    } else {
+        Write-Host "Selected $resolutionType Resolutions ($($filtered.Count)):" -ForegroundColor Yellow
+        foreach ($r in $filtered) {
+            Write-Host "  • $r" -ForegroundColor Green
+        }
     }
     Write-Host "==============================`n" -ForegroundColor Cyan
-    
+
     return $filtered.ToArray()
 }

--- a/E2E/Library/DeviceDetails.ps1
+++ b/E2E/Library/DeviceDetails.ps1
@@ -383,7 +383,7 @@ function GetPowerProfiles
     $pluggedInProfiles = FindAllElementsNameWithClassName $ui ComboBoxItem
     Start-Sleep -Seconds 2
     Write-Log -Message "Available power profiles: $pluggedInProfiles" -IsOutput | Out-Null
-    Stop-Process -Name 'systemsettings'
+    CloseApp 'systemsettings'
     
     return $pluggedInProfiles
 }

--- a/E2E/Library/LookUpTable.ps1
+++ b/E2E/Library/LookUpTable.ps1
@@ -1,4 +1,4 @@
-﻿<#
+<#
 DESCRIPTION:
     Builds a configuration array based on a set of input effects.
 

--- a/E2E/Library/LookUpTable.ps1
+++ b/E2E/Library/LookUpTable.ps1
@@ -143,6 +143,13 @@ function RetrieveValue($inputValue)
    $returnValues.Add("0.1 megapixels, 11 by 9 aspect ratio,  352 by 288 resolution" , '0.1MP')
    $returnValues.Add("0.03 megapixels, 11 by 9 aspect ratio,  176 by 144 resolution" ,'0.03MP')
 
+   # Power profile folder name to display name mappings
+   $returnValues.Add("BestPowerEfficiency", "Best Power Efficiency")
+   $returnValues.Add("Balanced", "Balanced")
+   $returnValues.Add("BestPerformance", "Best Performance")
+   $returnValues.Add("BetterPerformance", "Better Performance")
+   $returnValues.Add("Recommended", "Recommended")
+
    
    $outputValue = $returnValues[$inputValue]
    return $outputValue

--- a/E2E/Library/OcrHelper.ps1
+++ b/E2E/Library/OcrHelper.ps1
@@ -20,6 +20,7 @@ if (-not ([System.Management.Automation.PSTypeName]'Windows.Media.Ocr.OcrEngine'
         $null = [Windows.Graphics.Imaging.BitmapDecoder, Windows.Foundation, ContentType = WindowsRuntime]
         $null = [Windows.Graphics.Imaging.SoftwareBitmap, Windows.Foundation, ContentType = WindowsRuntime]
         $null = [Windows.Storage.Streams.RandomAccessStream, Windows.Foundation, ContentType = WindowsRuntime]
+        $null = [Windows.Globalization.Language, Windows.Foundation, ContentType = WindowsRuntime]
     } catch {
         Write-Warning "OCR WinRT types could not be loaded. Quick Settings OCR automation will not be available. Error: $_"
         $script:OcrAvailable = $false

--- a/E2E/Library/OcrHelper.ps1
+++ b/E2E/Library/OcrHelper.ps1
@@ -1,0 +1,292 @@
+<#
+DESCRIPTION:
+    OCR Helper module for Studio Effects automation.
+    Uses Windows.Media.Ocr.OcrEngine (built-in Windows OCR) to detect text in screenshots.
+    Designed to work with Quick Settings / Studio Effects flyout panels that are NOT exposed
+    in the UI Automation tree (see experiment findings 1 & 2).
+
+DEPENDENCIES:
+    - ScreenCapture.ps1 (Capture-ScreenRegion, Capture-RightScreenRegion)
+    - Windows 10/11 with Windows.Media.Ocr runtime
+#>
+
+# Load WinRT OCR types (guard against duplicate Add-Type calls — experiment 6 fix)
+if (-not ([System.Management.Automation.PSTypeName]'Windows.Media.Ocr.OcrEngine').Type) {
+    Add-Type -AssemblyName 'System.Runtime.WindowsRuntime'
+
+    $null = [Windows.Media.Ocr.OcrEngine, Windows.Foundation, ContentType = WindowsRuntime]
+    $null = [Windows.Graphics.Imaging.BitmapDecoder, Windows.Foundation, ContentType = WindowsRuntime]
+    $null = [Windows.Graphics.Imaging.SoftwareBitmap, Windows.Foundation, ContentType = WindowsRuntime]
+    $null = [Windows.Storage.Streams.RandomAccessStream, Windows.Foundation, ContentType = WindowsRuntime]
+}
+
+# Helper to await WinRT async operations from PowerShell using AsTask pattern
+function Await-WinRTAsync {
+    param ([object]$AsyncOp, [type]$ResultType)
+    try {
+        $asTaskGeneric = ([System.WindowsRuntimeSystemExtensions].GetMethods() |
+            Where-Object { $_.Name -eq 'AsTask' -and $_.GetParameters().Count -eq 1 -and $_.IsGenericMethod })[0]
+        $asTask = $asTaskGeneric.MakeGenericMethod($ResultType)
+        $task = $asTask.Invoke($null, @($AsyncOp))
+        $task.Wait()
+        return $task.Result
+    } catch {
+        # Fallback to awaiter pattern for older runtimes
+        $awaiter = $AsyncOp.GetAwaiter()
+        while (-not $awaiter.IsCompleted) { Start-Sleep -Milliseconds 50 }
+        return $awaiter.GetResult()
+    }
+}
+
+
+<#
+DESCRIPTION:
+    Converts a System.Drawing.Bitmap to a WinRT SoftwareBitmap for use with OcrEngine.
+INPUT PARAMETERS:
+    - Bitmap [System.Drawing.Bitmap] :- The GDI+ bitmap to convert.
+RETURN TYPE:
+    - [Windows.Graphics.Imaging.SoftwareBitmap]
+#>
+function ConvertTo-SoftwareBitmap {
+    param ([System.Drawing.Bitmap]$Bitmap)
+
+    # Save bitmap to a memory stream as PNG
+    $memStream = New-Object System.IO.MemoryStream
+    $Bitmap.Save($memStream, [System.Drawing.Imaging.ImageFormat]::Png)
+    $memStream.Position = 0
+
+    # Convert to WinRT IRandomAccessStream
+    $winrtStream = [Windows.Storage.Streams.InMemoryRandomAccessStream]::new()
+    $writer = [Windows.Storage.Streams.DataWriter]::new($winrtStream.GetOutputStreamAt(0))
+    $bytes = $memStream.ToArray()
+    $writer.WriteBytes($bytes)
+    $null = Await-WinRTAsync -AsyncOp $writer.StoreAsync() -ResultType ([uint32])
+    $null = Await-WinRTAsync -AsyncOp $writer.FlushAsync() -ResultType ([bool])
+    $winrtStream.Seek(0)
+
+    # Decode to SoftwareBitmap
+    $decoder = Await-WinRTAsync -AsyncOp ([Windows.Graphics.Imaging.BitmapDecoder]::CreateAsync($winrtStream)) -ResultType ([Windows.Graphics.Imaging.BitmapDecoder])
+    $softwareBitmap = Await-WinRTAsync -AsyncOp $decoder.GetSoftwareBitmapAsync() -ResultType ([Windows.Graphics.Imaging.SoftwareBitmap])
+
+    $memStream.Dispose()
+    return $softwareBitmap
+}
+
+
+<#
+DESCRIPTION:
+    Runs OCR on a System.Drawing.Bitmap and returns all detected text lines with their
+    bounding rectangles. Each result contains: Text, X, Y, Width, Height (in pixels
+    relative to the bitmap).
+INPUT PARAMETERS:
+    - Bitmap [System.Drawing.Bitmap] :- The screenshot bitmap to OCR.
+    - Language [string] :- BCP-47 language tag (default: "en-US").
+RETURN TYPE:
+    - [array] :- Array of objects with properties: Text, X, Y, Width, Height
+#>
+function Invoke-OCR {
+    param (
+        [System.Drawing.Bitmap]$Bitmap,
+        [string]$Language = "en-US"
+    )
+
+    $softwareBitmap = ConvertTo-SoftwareBitmap -Bitmap $Bitmap
+
+    # Create OCR engine
+    $lang = [Windows.Globalization.Language]::new($Language)
+    $ocrEngine = [Windows.Media.Ocr.OcrEngine]::TryCreateFromLanguage($lang)
+    if (-not $ocrEngine) {
+        Write-Error "OCR engine could not be created for language '$Language'. Ensure the language pack is installed."
+        return @()
+    }
+
+    # Run OCR
+    $ocrResult = Await-WinRTAsync -AsyncOp $ocrEngine.RecognizeAsync($softwareBitmap) -ResultType ([Windows.Media.Ocr.OcrResult])
+
+    # Extract results with bounding boxes (type-safe — experiment 5 fix)
+    $results = @()
+    foreach ($line in $ocrResult.Lines) {
+        $words = $line.Words
+        if ($words.Count -eq 0) { continue }
+
+        # Compute bounding rect for the entire line
+        $minX = [double]::MaxValue
+        $minY = [double]::MaxValue
+        $maxX = 0.0
+        $maxY = 0.0
+
+        foreach ($word in $words) {
+            $rect = $word.BoundingRect
+            $wx = [double]$rect.X
+            $wy = [double]$rect.Y
+            $ww = [double]$rect.Width
+            $wh = [double]$rect.Height
+
+            if ($wx -lt $minX) { $minX = $wx }
+            if ($wy -lt $minY) { $minY = $wy }
+            if (($wx + $ww) -gt $maxX) { $maxX = $wx + $ww }
+            if (($wy + $wh) -gt $maxY) { $maxY = $wy + $wh }
+        }
+
+        $results += [PSCustomObject]@{
+            Text   = $line.Text
+            X      = [int]$minX
+            Y      = [int]$minY
+            Width  = [int]($maxX - $minX)
+            Height = [int]($maxY - $minY)
+        }
+    }
+
+    return $results
+}
+
+
+<#
+DESCRIPTION:
+    Captures the right portion of the screen and runs OCR on it. Returns detected text
+    with bounding coordinates adjusted to absolute screen coordinates.
+    This is the primary function for detecting Studio Effects panel content.
+INPUT PARAMETERS:
+    - Fraction [double] :- Fraction of screen width to capture from right (default: 0.4).
+    - Language [string] :- OCR language (default: "en-US").
+RETURN TYPE:
+    - [array] :- Array of objects with properties: Text, ScreenX, ScreenY, Width, Height
+                 (coordinates are absolute screen positions for click targeting)
+#>
+function Get-RightScreenOCR {
+    param (
+        [double]$Fraction = 0.4,
+        [string]$Language = "en-US"
+    )
+
+    $screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
+    $captureWidth = [int]($screenWidth * $Fraction)
+    $offsetX = $screenWidth - $captureWidth
+
+    $bitmap = Capture-RightScreenRegion -Fraction $Fraction
+    $ocrResults = Invoke-OCR -Bitmap $bitmap -Language $Language
+    $bitmap.Dispose()
+
+    # Adjust coordinates from bitmap-relative to absolute screen coordinates
+    $adjusted = @()
+    foreach ($r in $ocrResults) {
+        $adjusted += [PSCustomObject]@{
+            Text    = $r.Text
+            ScreenX = $r.X + $offsetX
+            ScreenY = $r.Y
+            Width   = $r.Width
+            Height  = $r.Height
+        }
+    }
+
+    return $adjusted
+}
+
+
+<#
+DESCRIPTION:
+    Searches OCR results for a specific text string (case-insensitive partial match).
+    Returns the first matching result with screen coordinates.
+INPUT PARAMETERS:
+    - OcrResults [array] :- Array of OCR result objects from Get-RightScreenOCR or Invoke-OCR.
+    - SearchText [string] :- The text to search for (case-insensitive, partial match).
+RETURN TYPE:
+    - [object] :- The first matching OCR result, or $null if not found.
+#>
+function Find-OCRText {
+    param (
+        [array]$OcrResults,
+        [string]$SearchText
+    )
+
+    $match = $OcrResults | Where-Object { $_.Text -like "*$SearchText*" } | Select-Object -First 1
+    return $match
+}
+
+
+<#
+DESCRIPTION:
+    Clicks at a specific screen coordinate using mouse_event Win32 API.
+    Uses absolute coordinates with SendInput for reliable click delivery to
+    flyout panels not in the UI Automation tree.
+INPUT PARAMETERS:
+    - X [int] :- Absolute screen X coordinate.
+    - Y [int] :- Absolute screen Y coordinate.
+RETURN TYPE:
+    - void
+#>
+function Click-AtPosition {
+    param (
+        [int]$X,
+        [int]$Y
+    )
+
+    # Load user32.dll methods if not already loaded
+    if (-not ([System.Management.Automation.PSTypeName]'NativeMethods_OCR').Type) {
+        Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class NativeMethods_OCR {
+    [DllImport("user32.dll")]
+    public static extern bool SetCursorPos(int x, int y);
+
+    [DllImport("user32.dll")]
+    public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, int dwExtraInfo);
+
+    public const uint MOUSEEVENTF_LEFTDOWN = 0x0002;
+    public const uint MOUSEEVENTF_LEFTUP   = 0x0004;
+
+    public static void ClickAt(int x, int y) {
+        SetCursorPos(x, y);
+        System.Threading.Thread.Sleep(100);
+        mouse_event(MOUSEEVENTF_LEFTDOWN, 0, 0, 0, 0);
+        System.Threading.Thread.Sleep(50);
+        mouse_event(MOUSEEVENTF_LEFTUP, 0, 0, 0, 0);
+    }
+}
+"@
+    }
+
+    [NativeMethods_OCR]::ClickAt($X, $Y)
+    Write-Log -Message "Clicked at screen position ($X, $Y)" -IsOutput
+}
+
+
+<#
+DESCRIPTION:
+    Finds a text label on screen via OCR and clicks on it or near it.
+    Combines Get-RightScreenOCR, Find-OCRText, and Click-AtPosition.
+INPUT PARAMETERS:
+    - SearchText [string] :- The text to find on screen.
+    - OffsetX [int] :- Horizontal pixel offset from the center of the found text (default: 0).
+    - OffsetY [int] :- Vertical pixel offset from the center of the found text (default: 0).
+    - Fraction [double] :- Screen capture fraction (default: 0.4).
+RETURN TYPE:
+    - [bool] :- $true if text was found and clicked, $false otherwise.
+#>
+function Find-AndClickOCR {
+    param (
+        [string]$SearchText,
+        [int]$OffsetX = 0,
+        [int]$OffsetY = 0,
+        [double]$Fraction = 0.4
+    )
+
+    $ocrResults = Get-RightScreenOCR -Fraction $Fraction
+    $match = Find-OCRText -OcrResults $ocrResults -SearchText $SearchText
+
+    if (-not $match) {
+        Write-Warning "OCR: Text '$SearchText' not found on screen."
+        return $false
+    }
+
+    # Calculate click position (center of the detected text + offset)
+    $clickX = $match.ScreenX + [int]($match.Width / 2) + $OffsetX
+    $clickY = $match.ScreenY + [int]($match.Height / 2) + $OffsetY
+
+    Write-Log -Message "OCR: Found '$SearchText' at ($($match.ScreenX), $($match.ScreenY)) size ($($match.Width)x$($match.Height)). Clicking at ($clickX, $clickY)" -IsOutput
+    Click-AtPosition -X $clickX -Y $clickY
+
+    return $true
+}

--- a/E2E/Library/OcrHelper.ps1
+++ b/E2E/Library/OcrHelper.ps1
@@ -258,7 +258,7 @@ public class NativeMethods_OCR {
     }
 
     [NativeMethods_OCR]::ClickAt($X, $Y)
-    Write-Log -Message "Clicked at screen position ($X, $Y)" -IsOutput
+    Write-Log -Message "Clicked at screen position ($X, $Y)" -IsOutput | Out-Null
 }
 
 
@@ -294,7 +294,7 @@ function Find-AndClickOCR {
     $clickX = $match.ScreenX + [int]($match.Width / 2) + $OffsetX
     $clickY = $match.ScreenY + [int]($match.Height / 2) + $OffsetY
 
-    Write-Log -Message "OCR: Found '$SearchText' at ($($match.ScreenX), $($match.ScreenY)) size ($($match.Width)x$($match.Height)). Clicking at ($clickX, $clickY)" -IsOutput
+    Write-Log -Message "OCR: Found '$SearchText' at ($($match.ScreenX), $($match.ScreenY)) size ($($match.Width)x$($match.Height)). Clicking at ($clickX, $clickY)" -IsOutput | Out-Null
     Click-AtPosition -X $clickX -Y $clickY
 
     return $true

--- a/E2E/Library/OcrHelper.ps1
+++ b/E2E/Library/OcrHelper.ps1
@@ -11,14 +11,22 @@ DEPENDENCIES:
 #>
 
 # Load WinRT OCR types (guard against duplicate Add-Type calls — experiment 6 fix)
+# Also guard against environments where WinRT OCR is unavailable (e.g., PowerShell 7.6+)
 if (-not ([System.Management.Automation.PSTypeName]'Windows.Media.Ocr.OcrEngine').Type) {
-    Add-Type -AssemblyName 'System.Runtime.WindowsRuntime'
+    try {
+        Add-Type -AssemblyName 'System.Runtime.WindowsRuntime'
 
-    $null = [Windows.Media.Ocr.OcrEngine, Windows.Foundation, ContentType = WindowsRuntime]
-    $null = [Windows.Graphics.Imaging.BitmapDecoder, Windows.Foundation, ContentType = WindowsRuntime]
-    $null = [Windows.Graphics.Imaging.SoftwareBitmap, Windows.Foundation, ContentType = WindowsRuntime]
-    $null = [Windows.Storage.Streams.RandomAccessStream, Windows.Foundation, ContentType = WindowsRuntime]
+        $null = [Windows.Media.Ocr.OcrEngine, Windows.Foundation, ContentType = WindowsRuntime]
+        $null = [Windows.Graphics.Imaging.BitmapDecoder, Windows.Foundation, ContentType = WindowsRuntime]
+        $null = [Windows.Graphics.Imaging.SoftwareBitmap, Windows.Foundation, ContentType = WindowsRuntime]
+        $null = [Windows.Storage.Streams.RandomAccessStream, Windows.Foundation, ContentType = WindowsRuntime]
+    } catch {
+        Write-Warning "OCR WinRT types could not be loaded. Quick Settings OCR automation will not be available. Error: $_"
+        $script:OcrAvailable = $false
+        return
+    }
 }
+$script:OcrAvailable = $true
 
 # Helper to await WinRT async operations from PowerShell using AsTask pattern
 function Await-WinRTAsync {

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -254,14 +254,13 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
 DESCRIPTION:
     This function opens the Settings page -> System -> Power & battery -> Power mode. It waits for the UI
     and attempts to set the specified power profile for both "Plugged in" and "On battery" modes. If the Power profile 
-    is unsupported, the test is skipped and logged.
+    is unsupported, the function returns $false and logs a warning.
 INPUT PARAMETERS:
-    - ui [object] :- The UI automation element representing the Settings page.
     - powerProfile [string] :- The desired Power profile (e.g., "Balanced"/"Best Power Efficiency"/"Best Performance").
 RETURN TYPE:
-    - [bool] (Returns `$false` if the Power profile is unsupported, otherwise closes the app without returning a value.)
+    - [bool] Returns $false if the Power profile is not available in the UI, $true on success.
 #>
-function SetPowerProfileInSettingsPage($ui,$powerProfile)
+function SetPowerProfileInSettingsPage($powerProfile)
 {
     Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
 
@@ -272,6 +271,15 @@ function SetPowerProfileInSettingsPage($ui,$powerProfile)
     # Expand "Show more settings"
     FindAndClick $ui "ExpanderToggleButton" "Show more settings"
     Start-Sleep -Seconds 3
+
+    # Check if the requested power profile is available before attempting to click
+    $availableItems = FindAllElementsNameWithClassName $ui "ComboBoxItem"
+    if ($availableItems -notcontains $powerProfile) {
+        Write-Log -Message "Power profile '$powerProfile' is not available on this device. Skipping." -IsOutput
+        Write-Warning "Power profile '$powerProfile' not found in Settings UI. Available: $($availableItems -join ', ')"
+        CloseApp 'systemsettings'
+        return $false
+    }
     
     # Set "Plugged in" power mode
     Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput
@@ -288,4 +296,5 @@ function SetPowerProfileInSettingsPage($ui,$powerProfile)
     Start-Sleep -Seconds 3
     Write-Log -Message "On battery mode set to $powerProfile" -IsOutput
     Write-Log -Message "Power profile set to $powerProfile" -IsOutput
+    return $true
 }

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -262,7 +262,7 @@ RETURN TYPE:
 #>
 function SetPowerProfileInSettingsPage($powerProfile)
 {
-    Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
+    Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput | Out-Null
 
     # Navigate directly to Power page via URI
     $ui = OpenApp 'ms-settings:powersleep' 'Settings'
@@ -275,26 +275,26 @@ function SetPowerProfileInSettingsPage($powerProfile)
     # Check if the requested power profile is available before attempting to click
     $availableItems = FindAllElementsNameWithClassName $ui "ComboBoxItem"
     if ($availableItems -notcontains $powerProfile) {
-        Write-Log -Message "Power profile '$powerProfile' is not available on this device. Skipping." -IsOutput
+        Write-Log -Message "Power profile '$powerProfile' is not available on this device. Skipping." -IsOutput | Out-Null
         Write-Warning "Power profile '$powerProfile' not found in Settings UI. Available: $($availableItems -join ', ')"
         CloseApp 'systemsettings'
         return $false
     }
     
     # Set "Plugged in" power mode
-    Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput
+    Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput | Out-Null
     FindAndClick $ui "ComboBox" "Plugged in"
     Start-Sleep -Seconds 3
     FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
     Start-Sleep -Seconds 3
-    Write-Log -Message "Plugged in mode set to $powerProfile" -IsOutput
+    Write-Log -Message "Plugged in mode set to $powerProfile" -IsOutput | Out-Null
     
     # Set "On battery" power mode
     FindAndClick $ui "ComboBox" "On battery"
     Start-Sleep -Seconds 3
     FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
     Start-Sleep -Seconds 3
-    Write-Log -Message "On battery mode set to $powerProfile" -IsOutput
-    Write-Log -Message "Power profile set to $powerProfile" -IsOutput
+    Write-Log -Message "On battery mode set to $powerProfile" -IsOutput | Out-Null
+    Write-Log -Message "Power profile set to $powerProfile" -IsOutput | Out-Null
     return $true
 }

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -249,3 +249,43 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
      #close settings app
      CloseApp 'systemsettings'
 }
+
+<#
+DESCRIPTION:
+    This function opens the Settings page -> System -> Power & battery -> Power mode. It waits for the UI
+    and attempts to set the specified power profile for both "Plugged in" and "On battery" modes. If the Power profile 
+    is unsupported, the test is skipped and logged.
+INPUT PARAMETERS:
+    - ui [object] :- The UI automation element representing the Settings page.
+    - powerProfile [string] :- The desired Power profile (e.g., "Balanced"/"Best Power Efficiency"/"Best Performance").
+RETURN TYPE:
+    - [bool] (Returns `$false` if the Power profile is unsupported, otherwise closes the app without returning a value.)
+#>
+function SetPowerProfileInSettingsPage($ui,$powerProfile)
+{
+    Write-Log -Message "Opening Settings Page to set power profile..." -IsOutput
+
+    # Navigate directly to Power page via URI
+    $ui = OpenApp 'ms-settings:powersleep' 'Settings'
+    Start-Sleep -Seconds 3
+
+    # Expand "Show more settings"
+    FindAndClick $ui "ExpanderToggleButton" "Show more settings"
+    Start-Sleep -Seconds 3
+    
+    # Set "Plugged in" power mode
+    Write-Log -Message "Setting power profile to: $powerProfile" -IsOutput
+    FindAndClick $ui "ComboBox" "Plugged in"
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
+    Start-Sleep -Seconds 3
+    Write-Log -Message "Plugged in mode set to $powerProfile" -IsOutput
+    
+    # Set "On battery" power mode
+    FindAndClick $ui "ComboBox" "On battery"
+    Start-Sleep -Seconds 3
+    FindAndClick $ui "ComboBoxItem" -proptyNme $powerProfile
+    Start-Sleep -Seconds 3
+    Write-Log -Message "On battery mode set to $powerProfile" -IsOutput
+    Write-Log -Message "Power profile set to $powerProfile" -IsOutput
+}

--- a/E2E/Library/StudioEffectsHandler.ps1
+++ b/E2E/Library/StudioEffectsHandler.ps1
@@ -53,10 +53,10 @@ RETURN TYPE:
     - void
 #>
 function Open-QuickSettings {
-    Write-Log -Message "Opening Quick Settings (Win+A)..." -IsOutput
+    Write-Log -Message "Opening Quick Settings (Win+A)..." -IsOutput | Out-Null
     [QuickSettingsNative]::OpenQuickSettings()
     Start-Sleep -Seconds 2
-    Write-Log -Message "Quick Settings panel should be open." -IsOutput
+    Write-Log -Message "Quick Settings panel should be open." -IsOutput | Out-Null
 }
 
 
@@ -70,7 +70,7 @@ RETURN TYPE:
     - void
 #>
 function Close-QuickSettings {
-    Write-Log -Message "Closing Quick Settings (Escape)..." -IsOutput
+    Write-Log -Message "Closing Quick Settings (Escape)..." -IsOutput | Out-Null
     [QuickSettingsNative]::CloseQuickSettings()
     Start-Sleep -Milliseconds 500
 }
@@ -94,7 +94,7 @@ function Open-StudioEffects {
     Open-QuickSettings
 
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
-        Write-Log -Message "Looking for Studio Effects button (attempt $attempt/$MaxRetries)..." -IsOutput
+        Write-Log -Message "Looking for Studio Effects button (attempt $attempt/$MaxRetries)..." -IsOutput | Out-Null
 
         $ocrResults = Get-RightScreenOCR -Fraction 0.4
         $studioMatch = Find-OCRText -OcrResults $ocrResults -SearchText "Studio effects"
@@ -103,7 +103,7 @@ function Open-StudioEffects {
         }
 
         if ($studioMatch) {
-            Write-Log -Message "Found 'Studio Effects' at ($($studioMatch.ScreenX), $($studioMatch.ScreenY))" -IsOutput
+            Write-Log -Message "Found 'Studio Effects' at ($($studioMatch.ScreenX), $($studioMatch.ScreenY))" -IsOutput | Out-Null
             $clickX = $studioMatch.ScreenX + [int]($studioMatch.Width / 2)
             $clickY = $studioMatch.ScreenY + [int]($studioMatch.Height / 2)
             Click-AtPosition -X $clickX -Y $clickY
@@ -115,12 +115,12 @@ function Open-StudioEffects {
                         (Find-OCRText -OcrResults $verifyOcr -SearchText "Automatic framing") -or
                         (Find-OCRText -OcrResults $verifyOcr -SearchText "Eye contact")
             if ($verified) {
-                Write-Log -Message "Studio Effects flyout verified open." -IsOutput
+                Write-Log -Message "Studio Effects flyout verified open." -IsOutput | Out-Null
                 return $true
             }
-            Write-Log -Message "Studio Effects flyout not verified, retrying..." -IsOutput
+            Write-Log -Message "Studio Effects flyout not verified, retrying..." -IsOutput | Out-Null
         } else {
-            Write-Log -Message "Studio Effects button not found, retrying..." -IsOutput
+            Write-Log -Message "Studio Effects button not found, retrying..." -IsOutput | Out-Null
         }
         Start-Sleep -Seconds 1
     }
@@ -196,24 +196,24 @@ function Set-StudioEffectState {
     $screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
 
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
-        Write-Log -Message "Setting '$EffectName' to $DesiredState (attempt $attempt)..." -IsOutput
+        Write-Log -Message "Setting '$EffectName' to $DesiredState (attempt $attempt)..." -IsOutput | Out-Null
 
         $ocrResults = Get-RightScreenOCR -Fraction 0.4
         $match = Find-OCRText -OcrResults $ocrResults -SearchText $EffectName
         if (-not $match) {
-            Write-Log -Message "'$EffectName' not found on screen, retrying..." -IsOutput
+            Write-Log -Message "'$EffectName' not found on screen, retrying..." -IsOutput | Out-Null
             Start-Sleep -Seconds 1
             continue
         }
 
-        Write-Log -Message "Found '$EffectName' at ($($match.ScreenX), $($match.ScreenY))" -IsOutput
+        Write-Log -Message "Found '$EffectName' at ($($match.ScreenX), $($match.ScreenY))" -IsOutput | Out-Null
 
         # Check current state
         $currentState = Get-ToggleState -OcrResults $ocrResults -EffectMatch $match
-        Write-Log -Message "'$EffectName' current state: $currentState, desired: $DesiredState" -IsOutput
+        Write-Log -Message "'$EffectName' current state: $currentState, desired: $DesiredState" -IsOutput | Out-Null
 
         if ($currentState -eq $DesiredState) {
-            Write-Log -Message "'$EffectName' is already $DesiredState, no click needed." -IsOutput
+            Write-Log -Message "'$EffectName' is already $DesiredState, no click needed." -IsOutput | Out-Null
             return $true
         }
 
@@ -235,13 +235,13 @@ function Set-StudioEffectState {
             if ($verifyMatch) {
                 $newState = Get-ToggleState -OcrResults $verifyOcr -EffectMatch $verifyMatch
                 if ($newState -eq $DesiredState) {
-                    Write-Log -Message "'$EffectName' successfully set to $DesiredState (offset=$offset)." -IsOutput
+                    Write-Log -Message "'$EffectName' successfully set to $DesiredState (offset=$offset)." -IsOutput | Out-Null
                     return $true
                 }
-                Write-Log -Message "'$EffectName' state after click at offset $offset`: $newState (expected $DesiredState)" -IsOutput
+                Write-Log -Message "'$EffectName' state after click at offset $offset`: $newState (expected $DesiredState)" -IsOutput | Out-Null
             }
         }
-        Write-Log -Message "'$EffectName' toggle click did not achieve desired state, retrying full attempt..." -IsOutput
+        Write-Log -Message "'$EffectName' toggle click did not achieve desired state, retrying full attempt..." -IsOutput | Out-Null
     }
 
     Write-Warning "Could not set '$EffectName' to $DesiredState after $MaxRetries attempts."
@@ -272,10 +272,10 @@ function Verify-StudioEffectsState {
         if ($match) {
             $state = Get-ToggleState -OcrResults $ocrResults -EffectMatch $match
             $states[$name] = $state
-            Write-Log -Message "Verify: '$name' = $state" -IsOutput
+            Write-Log -Message "Verify: '$name' = $state" -IsOutput | Out-Null
         } else {
             $states[$name] = "NotFound"
-            Write-Log -Message "Verify: '$name' not found on screen" -IsOutput
+            Write-Log -Message "Verify: '$name' not found on screen" -IsOutput | Out-Null
         }
     }
 
@@ -303,7 +303,7 @@ function Select-StudioEffectOption {
     for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
         $result = Find-AndClickOCR -SearchText $OptionName -Fraction 0.4
         if ($result) {
-            Write-Log -Message "Selected Studio Effects option: '$OptionName'" -IsOutput
+            Write-Log -Message "Selected Studio Effects option: '$OptionName'" -IsOutput | Out-Null
             return $true
         }
         Start-Sleep -Seconds 1
@@ -360,7 +360,7 @@ function ToggleAIEffectsInQuickSettings {
         [string]$CFW    = "Off"
     )
 
-    Write-Log -Message "Entering ToggleAIEffectsInQuickSettings" -IsOutput
+    Write-Log -Message "Entering ToggleAIEffectsInQuickSettings" -IsOutput | Out-Null
     $allSuccess = $true
 
     try {
@@ -398,12 +398,12 @@ function ToggleAIEffectsInQuickSettings {
         # Portrait light and Creative filters may not exist on all devices
         $plResult = Set-StudioEffectState -EffectName "Portrait light" -DesiredState $PLVal
         if ($plResult -eq $false -and $PLVal -eq "On") {
-            Write-Log -Message "Portrait light not available on this device, skipping." -IsOutput
+            Write-Log -Message "Portrait light not available on this device, skipping." -IsOutput | Out-Null
         }
 
         $cfResult = Set-StudioEffectState -EffectName "Creative filters" -DesiredState $CF
         if ($cfResult -eq $false -and $CF -eq "On") {
-            Write-Log -Message "Creative filters not available on this device, skipping." -IsOutput
+            Write-Log -Message "Creative filters not available on this device, skipping." -IsOutput | Out-Null
         }
         if ($CF -eq "On" -and $cfResult) {
             if ($CFI -eq "On" -and -not (Select-StudioEffectOption -OptionName "Illustrated")) { $allSuccess = $false }
@@ -414,7 +414,7 @@ function ToggleAIEffectsInQuickSettings {
         # VFVal is intentionally not handled here — Voice Focus is not in the Quick Settings
         # Studio Effects panel. It must be toggled separately via VoiceFocusToggleSwitch.
         if ($VFVal -ne "Off") {
-            Write-Log -Message "Note: Voice Focus ($VFVal) is not available in Quick Settings. Use VoiceFocusToggleSwitch separately." -IsOutput
+            Write-Log -Message "Note: Voice Focus ($VFVal) is not available in Quick Settings. Use VoiceFocusToggleSwitch separately." -IsOutput | Out-Null
         }
 
     } finally {
@@ -423,7 +423,7 @@ function ToggleAIEffectsInQuickSettings {
     }
 
     if ($allSuccess) {
-        Write-Log -Message "All AI effects set successfully in Quick Settings." -IsOutput
+        Write-Log -Message "All AI effects set successfully in Quick Settings." -IsOutput | Out-Null
     } else {
         Write-Warning "Some effects could not be set in Quick Settings. Check logs for details."
     }

--- a/E2E/Library/StudioEffectsHandler.ps1
+++ b/E2E/Library/StudioEffectsHandler.ps1
@@ -1,0 +1,422 @@
+<#
+DESCRIPTION:
+    Studio Effects Handler for Quick Settings panel.
+    The Studio Effects flyout in Windows Quick Settings is NOT accessible via
+    UI Automation (experiments 1 & 2 confirmed this). This module uses OCR-based
+    detection and native mouse clicks to interact with the Studio Effects panel.
+
+DEPENDENCIES:
+    - OcrHelper.ps1 (Get-RightScreenOCR, Find-OCRText, Click-AtPosition, Find-AndClickOCR)
+    - ScreenCapture.ps1 (Capture-RightScreenRegion)
+    - Helper-library.ps1 (Write-Log)
+#>
+
+# Ensure native methods are loaded once at module scope
+if (-not ([System.Management.Automation.PSTypeName]'QuickSettingsNative').Type) {
+    Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public class QuickSettingsNative {
+    [DllImport("user32.dll")]
+    public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
+
+    public const byte VK_LWIN = 0x5B;
+    public const byte VK_A = 0x41;
+    public const uint KEYEVENTF_KEYUP = 0x0002;
+
+    public static void OpenQuickSettings() {
+        keybd_event(VK_LWIN, 0, 0, 0);
+        keybd_event(VK_A, 0, 0, 0);
+        System.Threading.Thread.Sleep(50);
+        keybd_event(VK_A, 0, KEYEVENTF_KEYUP, 0);
+        keybd_event(VK_LWIN, 0, KEYEVENTF_KEYUP, 0);
+    }
+
+    public static void CloseQuickSettings() {
+        keybd_event(0x1B, 0, 0, 0);           // VK_ESCAPE
+        System.Threading.Thread.Sleep(50);
+        keybd_event(0x1B, 0, KEYEVENTF_KEYUP, 0);
+    }
+}
+"@
+}
+
+
+<#
+DESCRIPTION:
+    Opens the Windows Quick Settings panel using the Win+A keyboard shortcut.
+    Waits for the panel to render before returning.
+INPUT PARAMETERS:
+    - None
+RETURN TYPE:
+    - void
+#>
+function Open-QuickSettings {
+    Write-Log -Message "Opening Quick Settings (Win+A)..." -IsOutput
+    [QuickSettingsNative]::OpenQuickSettings()
+    Start-Sleep -Seconds 2
+    Write-Log -Message "Quick Settings panel should be open." -IsOutput
+}
+
+
+<#
+DESCRIPTION:
+    Closes the Quick Settings panel by pressing Escape.
+    Note: Closing Quick Settings also closes Studio Effects flyout (experiment 3 finding).
+INPUT PARAMETERS:
+    - None
+RETURN TYPE:
+    - void
+#>
+function Close-QuickSettings {
+    Write-Log -Message "Closing Quick Settings (Escape)..." -IsOutput
+    [QuickSettingsNative]::CloseQuickSettings()
+    Start-Sleep -Milliseconds 500
+}
+
+
+<#
+DESCRIPTION:
+    Opens the Studio Effects flyout from Quick Settings. First opens Quick Settings,
+    then uses OCR to find and click the "Studio effects" button. Verifies the flyout
+    opened by checking for expected effect labels like "Background effects".
+INPUT PARAMETERS:
+    - MaxRetries [int] :- Number of retry attempts to find Studio Effects button (default: 3).
+RETURN TYPE:
+    - [bool] :- $true if Studio Effects panel opened and verified, $false otherwise.
+#>
+function Open-StudioEffects {
+    param (
+        [int]$MaxRetries = 3
+    )
+
+    Open-QuickSettings
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        Write-Log -Message "Looking for Studio Effects button (attempt $attempt/$MaxRetries)..." -IsOutput
+
+        $ocrResults = Get-RightScreenOCR -Fraction 0.4
+        $studioMatch = Find-OCRText -OcrResults $ocrResults -SearchText "Studio effects"
+        if (-not $studioMatch) {
+            $studioMatch = Find-OCRText -OcrResults $ocrResults -SearchText "Studio Effects"
+        }
+
+        if ($studioMatch) {
+            Write-Log -Message "Found 'Studio Effects' at ($($studioMatch.ScreenX), $($studioMatch.ScreenY))" -IsOutput
+            $clickX = $studioMatch.ScreenX + [int]($studioMatch.Width / 2)
+            $clickY = $studioMatch.ScreenY + [int]($studioMatch.Height / 2)
+            Click-AtPosition -X $clickX -Y $clickY
+            Start-Sleep -Seconds 2
+
+            # Verify the flyout actually opened by looking for known effect labels
+            $verifyOcr = Get-RightScreenOCR -Fraction 0.4
+            $verified = (Find-OCRText -OcrResults $verifyOcr -SearchText "Background effects") -or
+                        (Find-OCRText -OcrResults $verifyOcr -SearchText "Automatic framing") -or
+                        (Find-OCRText -OcrResults $verifyOcr -SearchText "Eye contact")
+            if ($verified) {
+                Write-Log -Message "Studio Effects flyout verified open." -IsOutput
+                return $true
+            }
+            Write-Log -Message "Studio Effects flyout not verified, retrying..." -IsOutput
+        } else {
+            Write-Log -Message "Studio Effects button not found, retrying..." -IsOutput
+        }
+        Start-Sleep -Seconds 1
+    }
+
+    Write-Warning "Could not open Studio Effects panel in Quick Settings after $MaxRetries attempts."
+    Close-QuickSettings
+    return $false
+}
+
+
+<#
+DESCRIPTION:
+    Detects whether a Studio Effects toggle is currently On or Off by looking for
+    nearby "On"/"Off" text in the OCR results near the effect label's Y position.
+INPUT PARAMETERS:
+    - OcrResults [array] :- OCR results from Get-RightScreenOCR.
+    - EffectMatch [object] :- The OCR match object for the effect label.
+RETURN TYPE:
+    - [string] :- "On", "Off", or "Unknown" if state cannot be determined.
+#>
+function Get-ToggleState {
+    param (
+        [array]$OcrResults,
+        [object]$EffectMatch
+    )
+
+    $labelY = $EffectMatch.ScreenY
+    $tolerance = 40  # pixels vertical tolerance for same-row matching
+
+    # Look for "On" or "Off" text on the same row (within Y tolerance) and to the right
+    foreach ($r in $OcrResults) {
+        if ([Math]::Abs($r.ScreenY - $labelY) -le $tolerance -and $r.ScreenX -gt $EffectMatch.ScreenX) {
+            if ($r.Text -match '\bOn\b') { return "On" }
+            if ($r.Text -match '\bOff\b') { return "Off" }
+        }
+    }
+
+    # Fallback: check within a wider range below the label (some layouts stack vertically)
+    foreach ($r in $OcrResults) {
+        $vertDist = $r.ScreenY - $labelY
+        if ($vertDist -ge 0 -and $vertDist -le 60 -and $r.ScreenX -gt ($EffectMatch.ScreenX + $EffectMatch.Width - 50)) {
+            if ($r.Text -match '\bOn\b') { return "On" }
+            if ($r.Text -match '\bOff\b') { return "Off" }
+        }
+    }
+
+    return "Unknown"
+}
+
+
+<#
+DESCRIPTION:
+    Sets a Studio Effects toggle to a desired state. Uses OCR to detect current state
+    and only clicks the toggle if the current state differs from the desired state.
+    This makes the function idempotent — calling it multiple times produces the same result.
+
+    The toggle control is located relative to the right edge of the captured region
+    to be more resilient across resolutions and DPI settings.
+INPUT PARAMETERS:
+    - EffectName [string] :- The display name of the effect (e.g., "Background effects").
+    - DesiredState [string] :- The desired state ("On" or "Off").
+    - MaxRetries [int] :- Max retry attempts (default: 3).
+RETURN TYPE:
+    - [bool] :- $true if the effect was set to the desired state, $false if not found.
+#>
+function Set-StudioEffectState {
+    param (
+        [string]$EffectName,
+        [string]$DesiredState = "On",
+        [int]$MaxRetries = 3
+    )
+
+    $screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        Write-Log -Message "Setting '$EffectName' to $DesiredState (attempt $attempt)..." -IsOutput
+
+        $ocrResults = Get-RightScreenOCR -Fraction 0.4
+        $match = Find-OCRText -OcrResults $ocrResults -SearchText $EffectName
+        if (-not $match) {
+            Write-Log -Message "'$EffectName' not found on screen, retrying..." -IsOutput
+            Start-Sleep -Seconds 1
+            continue
+        }
+
+        Write-Log -Message "Found '$EffectName' at ($($match.ScreenX), $($match.ScreenY))" -IsOutput
+
+        # Check current state
+        $currentState = Get-ToggleState -OcrResults $ocrResults -EffectMatch $match
+        Write-Log -Message "'$EffectName' current state: $currentState, desired: $DesiredState" -IsOutput
+
+        if ($currentState -eq $DesiredState) {
+            Write-Log -Message "'$EffectName' is already $DesiredState, no click needed." -IsOutput
+            return $true
+        }
+
+        # Click toggle: try multiple candidate X positions relative to the right edge.
+        # The toggle switch is typically near the right edge of the flyout panel but
+        # exact position varies by DPI, resolution, and Windows build.
+        $clickY = $match.ScreenY + [int]($match.Height / 2)
+        $toggleOffsets = @(60, 45, 80, 100)  # pixels from right edge to try
+
+        $toggled = $false
+        foreach ($offset in $toggleOffsets) {
+            $clickX = $screenWidth - $offset
+            Click-AtPosition -X $clickX -Y $clickY
+            Start-Sleep -Milliseconds 800
+
+            # Verify the toggle changed
+            $verifyOcr = Get-RightScreenOCR -Fraction 0.4
+            $verifyMatch = Find-OCRText -OcrResults $verifyOcr -SearchText $EffectName
+            if ($verifyMatch) {
+                $newState = Get-ToggleState -OcrResults $verifyOcr -EffectMatch $verifyMatch
+                if ($newState -eq $DesiredState) {
+                    Write-Log -Message "'$EffectName' successfully set to $DesiredState (offset=$offset)." -IsOutput
+                    return $true
+                }
+                Write-Log -Message "'$EffectName' state after click at offset $offset`: $newState (expected $DesiredState)" -IsOutput
+            }
+        }
+        if (-not $toggled) {
+            Write-Log -Message "'$EffectName' toggle click did not achieve desired state, retrying full attempt..." -IsOutput
+        }
+    }
+
+    Write-Warning "Could not set '$EffectName' to $DesiredState after $MaxRetries attempts."
+    return $false
+}
+
+
+<#
+DESCRIPTION:
+    Verifies the current state of all visible Studio Effects toggles by reading OCR.
+    Returns a hashtable of effect names and their detected states.
+    Useful for confirming effects are set correctly after toggling.
+INPUT PARAMETERS:
+    - EffectNames [string[]] :- Array of effect label names to check.
+RETURN TYPE:
+    - [hashtable] :- Keys are effect names, values are "On", "Off", or "Unknown".
+#>
+function Verify-StudioEffectsState {
+    param (
+        [string[]]$EffectNames = @("Automatic framing", "Background effects", "Eye contact", "Portrait light", "Creative filters")
+    )
+
+    $ocrResults = Get-RightScreenOCR -Fraction 0.4
+    $states = @{}
+
+    foreach ($name in $EffectNames) {
+        $match = Find-OCRText -OcrResults $ocrResults -SearchText $name
+        if ($match) {
+            $state = Get-ToggleState -OcrResults $ocrResults -EffectMatch $match
+            $states[$name] = $state
+            Write-Log -Message "Verify: '$name' = $state" -IsOutput
+        } else {
+            $states[$name] = "NotFound"
+            Write-Log -Message "Verify: '$name' not found on screen" -IsOutput
+        }
+    }
+
+    return $states
+}
+
+
+<#
+DESCRIPTION:
+    Selects a radio-button style sub-option within Studio Effects panel by clicking on its label text.
+    Used for options like "Standard blur" vs "Portrait blur", or "Standard" vs "Teleprompter"
+    for Eye Contact.
+INPUT PARAMETERS:
+    - OptionName [string] :- The text of the sub-option to select (e.g., "Standard blur").
+    - MaxRetries [int] :- Max retry attempts (default: 3).
+RETURN TYPE:
+    - [bool] :- $true if option found and clicked, $false otherwise.
+#>
+function Select-StudioEffectOption {
+    param (
+        [string]$OptionName,
+        [int]$MaxRetries = 3
+    )
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        $result = Find-AndClickOCR -SearchText $OptionName -Fraction 0.4
+        if ($result) {
+            Write-Log -Message "Selected Studio Effects option: '$OptionName'" -IsOutput
+            return $true
+        }
+        Start-Sleep -Seconds 1
+    }
+
+    Write-Warning "Could not find Studio Effects option '$OptionName'."
+    return $false
+}
+
+
+<#
+DESCRIPTION:
+    Toggles all AI camera effects via the Quick Settings Studio Effects panel.
+    This is the Quick Settings equivalent of ToggleAIEffectsInSettingsApp.
+    Parameter order matches ToggleAIEffectsInSettingsApp for interchangeability.
+    Opens Studio Effects, sets each effect to the desired state, then closes.
+    Note: Voice Focus (VFVal) is not available in the Quick Settings Studio Effects panel;
+    it is handled separately through the Settings app.
+INPUT PARAMETERS:
+    - AFVal [string] :- "On"/"Off" for Automatic Framing.
+    - AFSVal [string] :- "On"/"Off" for Standard Framing (sub-option).
+    - AFCVal [string] :- "On"/"Off" for Cinematic Framing (sub-option).
+    - PLVal [string] :- "On"/"Off" for Portrait Light.
+    - BBVal [string] :- "On"/"Off" for Background Effects.
+    - BSVal [string] :- "On"/"Off" for Standard Blur (sub-option).
+    - BPVal [string] :- "On"/"Off" for Portrait Blur (sub-option).
+    - ECVal [string] :- "On"/"Off" for Eye Contact.
+    - ECSVal [string] :- "On"/"Off" for Standard Eye Contact style.
+    - ECTVal [string] :- "On"/"Off" for Teleprompter Eye Contact style.
+    - VFVal [string] :- Voice Focus (ignored in Quick Settings, handled via Settings app).
+    - CF [string] :- "On"/"Off" for Creative Filters.
+    - CFI [string] :- "On"/"Off" for Illustrated filter.
+    - CFA [string] :- "On"/"Off" for Animated filter.
+    - CFW [string] :- "On"/"Off" for Watercolor filter.
+RETURN TYPE:
+    - [bool] :- $true if all requested effects were set successfully, $false if any failed.
+#>
+function ToggleAIEffectsInQuickSettings {
+    param (
+        [string]$AFVal  = "Off",
+        [string]$AFSVal = "Off",
+        [string]$AFCVal = "Off",
+        [string]$PLVal  = "Off",
+        [string]$BBVal  = "Off",
+        [string]$BSVal  = "Off",
+        [string]$BPVal  = "Off",
+        [string]$ECVal  = "Off",
+        [string]$ECSVal = "Off",
+        [string]$ECTVal = "Off",
+        [string]$VFVal  = "Off",
+        [string]$CF     = "Off",
+        [string]$CFI    = "Off",
+        [string]$CFA    = "Off",
+        [string]$CFW    = "Off"
+    )
+
+    Write-Log -Message "Entering ToggleAIEffectsInQuickSettings" -IsOutput
+    $allSuccess = $true
+
+    try {
+        # Open Studio Effects panel
+        $opened = Open-StudioEffects
+        if (-not $opened) {
+            Write-Error "Failed to open Studio Effects panel in Quick Settings."
+            return $false
+        }
+
+        # Set main effects with state verification
+        if (-not (Set-StudioEffectState -EffectName "Automatic framing" -DesiredState $AFVal)) { $allSuccess = $false }
+        if ($AFVal -eq "On") {
+            if ($AFSVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Standard framing")) { $allSuccess = $false }
+            if ($AFCVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Cinematic framing")) { $allSuccess = $false }
+        }
+
+        if (-not (Set-StudioEffectState -EffectName "Background effects" -DesiredState $BBVal)) { $allSuccess = $false }
+        if ($BBVal -eq "On") {
+            if ($BSVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Standard blur")) { $allSuccess = $false }
+            if ($BPVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Portrait blur")) { $allSuccess = $false }
+        }
+
+        if (-not (Set-StudioEffectState -EffectName "Eye contact" -DesiredState $ECVal)) { $allSuccess = $false }
+        if ($ECVal -eq "On") {
+            if ($ECSVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Standard")) { $allSuccess = $false }
+            if ($ECTVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Teleprompter")) { $allSuccess = $false }
+        }
+
+        if (-not (Set-StudioEffectState -EffectName "Portrait light" -DesiredState $PLVal)) { $allSuccess = $false }
+
+        if (-not (Set-StudioEffectState -EffectName "Creative filters" -DesiredState $CF)) { $allSuccess = $false }
+        if ($CF -eq "On") {
+            if ($CFI -eq "On" -and -not (Select-StudioEffectOption -OptionName "Illustrated")) { $allSuccess = $false }
+            if ($CFA -eq "On" -and -not (Select-StudioEffectOption -OptionName "Animated")) { $allSuccess = $false }
+            if ($CFW -eq "On" -and -not (Select-StudioEffectOption -OptionName "Watercolor")) { $allSuccess = $false }
+        }
+
+        # VFVal is intentionally not handled here — Voice Focus is not in the Quick Settings
+        # Studio Effects panel. It must be toggled separately via VoiceFocusToggleSwitch.
+        if ($VFVal -ne "Off") {
+            Write-Log -Message "Note: Voice Focus ($VFVal) is not available in Quick Settings. Use VoiceFocusToggleSwitch separately." -IsOutput
+        }
+
+    } finally {
+        # Always close Quick Settings to prevent UI state pollution
+        Close-QuickSettings
+    }
+
+    if ($allSuccess) {
+        Write-Log -Message "All AI effects set successfully in Quick Settings." -IsOutput
+    } else {
+        Write-Warning "Some effects could not be set in Quick Settings. Check logs for details."
+    }
+
+    return $allSuccess
+}

--- a/E2E/Library/StudioEffectsHandler.ps1
+++ b/E2E/Library/StudioEffectsHandler.ps1
@@ -223,7 +223,7 @@ function Set-StudioEffectState {
         $clickY = $match.ScreenY + [int]($match.Height / 2)
         $toggleOffsets = @(60, 45, 80, 100)  # pixels from right edge to try
 
-        $toggled = $false
+        $toggleSuccess = $false
         foreach ($offset in $toggleOffsets) {
             $clickX = $screenWidth - $offset
             Click-AtPosition -X $clickX -Y $clickY
@@ -241,9 +241,7 @@ function Set-StudioEffectState {
                 Write-Log -Message "'$EffectName' state after click at offset $offset`: $newState (expected $DesiredState)" -IsOutput
             }
         }
-        if (-not $toggled) {
-            Write-Log -Message "'$EffectName' toggle click did not achieve desired state, retrying full attempt..." -IsOutput
-        }
+        Write-Log -Message "'$EffectName' toggle click did not achieve desired state, retrying full attempt..." -IsOutput
     }
 
     Write-Warning "Could not set '$EffectName' to $DesiredState after $MaxRetries attempts."
@@ -374,28 +372,40 @@ function ToggleAIEffectsInQuickSettings {
         }
 
         # Set main effects with state verification
-        if (-not (Set-StudioEffectState -EffectName "Automatic framing" -DesiredState $AFVal)) { $allSuccess = $false }
+        # Only treat as failure if the effect is visible but cannot be toggled.
+        # Effects not found on screen are skipped (device may not support them).
+        $afResult = Set-StudioEffectState -EffectName "Automatic framing" -DesiredState $AFVal
+        if ($afResult -eq $false -and $AFVal -eq "On") { $allSuccess = $false }
         if ($AFVal -eq "On") {
             if ($AFSVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Standard framing")) { $allSuccess = $false }
             if ($AFCVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Cinematic framing")) { $allSuccess = $false }
         }
 
-        if (-not (Set-StudioEffectState -EffectName "Background effects" -DesiredState $BBVal)) { $allSuccess = $false }
+        $bbResult = Set-StudioEffectState -EffectName "Background effects" -DesiredState $BBVal
+        if ($bbResult -eq $false -and $BBVal -eq "On") { $allSuccess = $false }
         if ($BBVal -eq "On") {
             if ($BSVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Standard blur")) { $allSuccess = $false }
             if ($BPVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Portrait blur")) { $allSuccess = $false }
         }
 
-        if (-not (Set-StudioEffectState -EffectName "Eye contact" -DesiredState $ECVal)) { $allSuccess = $false }
+        $ecResult = Set-StudioEffectState -EffectName "Eye contact" -DesiredState $ECVal
+        if ($ecResult -eq $false -and $ECVal -eq "On") { $allSuccess = $false }
         if ($ECVal -eq "On") {
             if ($ECSVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Standard")) { $allSuccess = $false }
             if ($ECTVal -eq "On" -and -not (Select-StudioEffectOption -OptionName "Teleprompter")) { $allSuccess = $false }
         }
 
-        if (-not (Set-StudioEffectState -EffectName "Portrait light" -DesiredState $PLVal)) { $allSuccess = $false }
+        # Portrait light and Creative filters may not exist on all devices
+        $plResult = Set-StudioEffectState -EffectName "Portrait light" -DesiredState $PLVal
+        if ($plResult -eq $false -and $PLVal -eq "On") {
+            Write-Log -Message "Portrait light not available on this device, skipping." -IsOutput
+        }
 
-        if (-not (Set-StudioEffectState -EffectName "Creative filters" -DesiredState $CF)) { $allSuccess = $false }
-        if ($CF -eq "On") {
+        $cfResult = Set-StudioEffectState -EffectName "Creative filters" -DesiredState $CF
+        if ($cfResult -eq $false -and $CF -eq "On") {
+            Write-Log -Message "Creative filters not available on this device, skipping." -IsOutput
+        }
+        if ($CF -eq "On" -and $cfResult) {
             if ($CFI -eq "On" -and -not (Select-StudioEffectOption -OptionName "Illustrated")) { $allSuccess = $false }
             if ($CFA -eq "On" -and -not (Select-StudioEffectOption -OptionName "Animated")) { $allSuccess = $false }
             if ($CFW -eq "On" -and -not (Select-StudioEffectOption -OptionName "Watercolor")) { $allSuccess = $false }

--- a/E2E/Library/StudioEffectsHandler.ps1
+++ b/E2E/Library/StudioEffectsHandler.ps1
@@ -21,9 +21,16 @@ public class QuickSettingsNative {
     [DllImport("user32.dll")]
     public static extern void keybd_event(byte bVk, byte bScan, uint dwFlags, int dwExtraInfo);
 
+    [DllImport("user32.dll")]
+    public static extern bool SetCursorPos(int x, int y);
+
+    [DllImport("user32.dll")]
+    public static extern void mouse_event(uint dwFlags, uint dx, uint dy, uint dwData, int dwExtraInfo);
+
     public const byte VK_LWIN = 0x5B;
     public const byte VK_A = 0x41;
     public const uint KEYEVENTF_KEYUP = 0x0002;
+    public const uint MOUSEEVENTF_WHEEL = 0x0800;
 
     public static void OpenQuickSettings() {
         keybd_event(VK_LWIN, 0, 0, 0);
@@ -37,6 +44,13 @@ public class QuickSettingsNative {
         keybd_event(0x1B, 0, 0, 0);           // VK_ESCAPE
         System.Threading.Thread.Sleep(50);
         keybd_event(0x1B, 0, KEYEVENTF_KEYUP, 0);
+    }
+
+    // Scroll down at a given screen position (negative dwData = scroll down)
+    public static void ScrollDown(int x, int y, int clicks) {
+        SetCursorPos(x, y);
+        System.Threading.Thread.Sleep(100);
+        mouse_event(MOUSEEVENTF_WHEEL, 0, 0, (uint)(-120 * clicks), 0);
     }
 }
 "@
@@ -97,9 +111,17 @@ function Open-StudioEffects {
         Write-Log -Message "Looking for Studio Effects button (attempt $attempt/$MaxRetries)..." -IsOutput | Out-Null
 
         $ocrResults = Get-RightScreenOCR -Fraction 0.4
+
+        # Log all detected text for diagnostics
+        $allText = ($ocrResults | ForEach-Object { $_.Text }) -join ' | '
+        Write-Log -Message "OCR detected text: $allText" -IsOutput | Out-Null
+
         $studioMatch = Find-OCRText -OcrResults $ocrResults -SearchText "Studio effects"
         if (-not $studioMatch) {
             $studioMatch = Find-OCRText -OcrResults $ocrResults -SearchText "Studio Effects"
+        }
+        if (-not $studioMatch) {
+            $studioMatch = Find-OCRText -OcrResults $ocrResults -SearchText "Studio effect"
         }
 
         if ($studioMatch) {
@@ -120,7 +142,14 @@ function Open-StudioEffects {
             }
             Write-Log -Message "Studio Effects flyout not verified, retrying..." -IsOutput | Out-Null
         } else {
-            Write-Log -Message "Studio Effects button not found, retrying..." -IsOutput | Out-Null
+            Write-Log -Message "Studio Effects button not found in OCR results, scrolling down..." -IsOutput | Out-Null
+            # Scroll down in Quick Settings to reveal Studio Effects if below fold
+            $screenWidth = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Width
+            $screenHeight = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds.Height
+            $scrollX = $screenWidth - [int]($screenWidth * 0.2)  # center of right panel
+            $scrollY = [int]($screenHeight * 0.6)  # mid-lower area
+            [QuickSettingsNative]::ScrollDown($scrollX, $scrollY, 3)
+            Start-Sleep -Seconds 1
         }
         Start-Sleep -Seconds 1
     }

--- a/E2E/QuickSettingsScenarioTest.ps1
+++ b/E2E/QuickSettingsScenarioTest.ps1
@@ -153,7 +153,7 @@ if($voiceFocusExists -eq $false)
 # Set up Power Profile
 Write-Log -Message "Setting up Power Profile to $powerProfile" | Out-File -FilePath "$pathLogsFolder\QuickSettingsScenarioTesting.txt" -Append
 SetPowerProfileInSettingsPage -powerProfile $powerProfile
-Stop-Process -Name 'systemsettings'
+CloseApp 'systemsettings'
 
 if($toggleAIEffects -eq "All")
 {

--- a/E2E/QuickSettingsScenarioTest.ps1
+++ b/E2E/QuickSettingsScenarioTest.ps1
@@ -1,0 +1,174 @@
+<#
+.SYNOPSIS
+    Executes Camera App scenario testing with AI effects toggled via Quick Settings Studio Effects panel.
+
+.DESCRIPTION
+    This script is the Quick Settings variant of ScenarioTest.ps1. It tests Camera App functionality
+    by configuring video and photo resolutions, toggling AI camera effects through the Quick Settings
+    Studio Effects flyout (using OCR-based interaction), validating voice focus behavior, and handling
+    device power states.
+
+    The Studio Effects flyout in Windows Quick Settings is not accessible via UI Automation,
+    so this script uses Windows.Media.Ocr to detect and interact with the panel controls.
+
+    Use this script instead of ScenarioTest.ps1 when you need to validate that effects toggled
+    from Quick Settings (rather than the Settings app) produce the same camera behavior.
+
+.PARAMETER token
+    Authentication token required to control the smart plug for power state changes.
+
+.PARAMETER SPId
+    Smart plug ID used to control device power states during testing.
+
+.PARAMETER targetMepCameraVer
+    Target MEP Camera component version to validate against the installed version.
+
+.PARAMETER targetMepAudioVer
+    Target MEP Audio component version to validate against the installed version.
+
+.PARAMETER targetPerceptionCoreVer
+    Target Perception Core component version to validate against the installed version.
+
+.PARAMETER logFile
+    Path to the log file where scenario test results will be recorded.
+
+.PARAMETER toggleAIEffects
+    Array of AI camera effect combinations to be applied during testing.
+    Each element represents a single test iteration and may contain multiple effects
+    combined using the "+" symbol.
+
+    Supported AI Effects:
+        AF   - Auto Framing (AFS/AFC for Standard/Cinematic)
+        PL   - Portrait Light
+        ECS  - Eye Contact (Standard)
+        ECT  - Eye Contact (Teleprompter)
+        BBS  - Background Blur (Standard)
+        BBP  - Background Blur (Portrait)
+        CF-I - Creative Filter (Illustrated)
+        CF-A - Creative Filter (Animated)
+        CF-W - Creative Filter (Watercolor)
+
+    Example values:
+        "AF+BBS+ECS"
+        "AF+BBP+ECS"
+        "AF+CF-I+PL+BBS"
+
+    If set to "All", the script dynamically retrieves all supported AI effect combinations
+    from the device and executes tests for each.
+
+.PARAMETER initSetUpDone
+    Indicates whether the initial setup has already been completed.
+    Accepted values: "true", "false".
+
+.PARAMETER camsnario
+    Specifies the Camera App test scenario.
+    Accepted values: "Recording", "Previewing".
+
+.PARAMETER VF
+    Voice Focus configuration. Note: Voice Focus is toggled via the Settings app
+    even in this Quick Settings variant, as it is not available in the Studio Effects flyout.
+    Accepted values: On, Off, NA
+
+.PARAMETER vdoRes
+    Video resolution setting to be applied in the Camera App.
+
+.PARAMETER ptoRes
+    Photo resolution setting to be applied in the Camera App.
+
+.PARAMETER devPowStat
+    Device power state during testing.
+    Accepted values: Pluggedin, Unplugged
+
+.PARAMETER powerProfile
+    Windows power mode setting used during the test.
+
+.EXAMPLE
+    Run the script using all default values:
+        .\QuickSettingsScenarioTest.ps1
+
+.EXAMPLE
+    Run with specific AI effects:
+        .\QuickSettingsScenarioTest.ps1 -toggleAIEffects "AF+BBS+ECS" , "AF+BBP+ECS"
+
+.OUTPUTS
+    None. This script does not return a value.
+#>
+
+
+param (
+   [string] $token = $null,
+   [string] $SPId = $null,
+   [string] $targetMepCameraVer = $null,
+   [string] $targetMepAudioVer = $null,
+   [string] $targetPerceptionCoreVer = $null,
+   [string] $logFile = "QuickSettingsScenarioTesting.txt",
+   
+   #AF:Auto-framing, PL:Portrait light, ECS:Eye contact(Standard), ECT:Eye Contact(Teleprompter), BBS:BackgroundBlur(Standard), BBP:BackgroundBlur(Portrait) 
+   #CF-I:Creative filter-Illustrated, CF-A:Creative filter-Animated, CF-W:Creative filter-Watercolor
+   #You can combine multiple effects using the "+" symbol. Here are some examples: 'AF+CF-I+PL+BBS', 'AF+CF-I+PL+BBP', 'AF+CF-I+ECS+BBS', 'AF+CF-I+ECS+BBP', 'AF+CF-I+ECT+BBS'
+
+   [string[]] $toggleAIEffects = @("AF+BBS+ECS","AF+BBP+ECS"),  # Default if not provided
+   
+   [ValidateSet("true" , "false")]
+   [string] $initSetUpDone = "false",  # Default if not provided
+
+   [ValidateSet("Recording" , "Previewing")]
+   [string] $camsnario = "Recording",  # Default if not provided
+
+   [ValidateSet("On", "Off", "NA")]
+   [string] $VF = "On",   # Default if not provided
+
+   [ValidateSet("1440p, 16 by 9 aspect ratio, 30 fps" , "1080p, 16 by 9 aspect ratio, 30 fps" ,"720p, 16 by 9 aspect ratio, 30 fps",`
+                "480p, 4 by 3 aspect ratio, 30 fps" , "360p, 16 by 9 aspect ratio, 30 fps" , "1440p, 4 by 3 aspect ratio, 30 fps" ,`
+                "1080p, 4 by 3 aspect ratio, 30 fps" , "960p, 4 by 3 aspect ratio, 30 fps" , "640p, 1 by 1 aspect ratio, 30 fps" ,`
+                "540p, 16 by 9 aspect ratio, 30 fps")]
+   [string] $vdoRes = "1080p, 16 by 9 aspect ratio, 30 fps",  # Default if not provided 
+
+   [ValidateSet("8.3 megapixels, 16 by 9 aspect ratio,  3840 by 2160 resolution" , "12.2 megapixels, 4 by 3 aspect ratio,  4032 by 3024 resolution" ,`
+                "5.0 megapixels, 4 by 3 aspect ratio,  2592 by 1944 resolution" , "4.5 megapixels, 3 by 2 aspect ratio,  2592 by 1728 resolution" ,`
+                "3.8 megapixels, 16 by 9 aspect ratio,  2592 by 1458 resolution" , "2.1 megapixels, 16 by 9 aspect ratio,  1920 by 1080 resolution" ,`
+                "1.6 megapixels, 4 by 3 aspect ratio,  1440 by 1080 resolution" , "0.9 megapixels, 16 by 9 aspect ratio,  1280 by 720 resolution" ,`
+                "0.8 megapixels, 4 by 3 aspect ratio,  1024 by 768 resolution" , "0.3 megapixels, 4 by 3 aspect ratio,  640 by 480 resolution" ,`
+                "0.2 megapixels, 16 by 9 aspect ratio,  640 by 360 resolution" , "1.2 megapixels, 4 by 3 aspect ratio,  1280 by 960 resolution" ,`
+                "0.08 megapixels, 4 by 3 aspect ratio,  320 by 240 resolution" , "0.02 megapixels, 4 by 3 aspect ratio,  160 by 120 resolution" ,`
+                "0.1 megapixels, 11 by 9 aspect ratio,  352 by 288 resolution" , "0.03 megapixels, 11 by 9 aspect ratio,  176 by 144 resolution")]
+   [string] $ptoRes = "2.1 megapixels, 16 by 9 aspect ratio,  1920 by 1080 resolution",  # Default if not provided
+
+   [ValidateSet("Pluggedin", "Unplugged")]
+   [string] $devPowStat = "Pluggedin",  # Default if not provided
+
+   [ValidateSet("Best Power Efficiency", "Balanced", "Best Performance")]
+   [string] $powerProfile = "Balanced"  # Default if not provided
+
+)
+.".\CheckInTest\Helper-library.ps1"
+InitializeTest 'QuickSettingsScenarioTesting'
+$voiceFocusExists = CheckVoiceFocusPolicy  
+if($voiceFocusExists -eq $false)
+{
+   $VF = "NA"
+}
+
+# Set up Power Profile
+Write-Log -Message "Setting up Power Profile to $powerProfile" | Out-File -FilePath "$pathLogsFolder\QuickSettingsScenarioTesting.txt" -Append
+SetPowerProfileInSettingsPage -powerProfile $powerProfile
+Stop-Process -Name 'systemsettings'
+
+if($toggleAIEffects -eq "All")
+{
+   $deviceData = GetDeviceDetails
+   $toggleAIEffects = $deviceData["ToggleAiEffect"]
+}    
+foreach ($togAiEfft in $toggleAIEffects)
+{
+   CameraAppTestQuickSettings -token $token -SPId $SPId -logFile $logFile -initSetUpDone $initSetUpDone -powerProfile $powerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\QuickSettingsScenarioTesting.txt"
+}
+
+[console]::beep(500,300)
+if($token.Length -ne 0 -and $SPId.Length -ne 0)
+{
+   SetSmartPlugState $token $SPId 1
+}
+[console]::beep(500,300)
+ 
+ConvertTxtFileToExcel "$pathLogsFolder\Report.txt"

--- a/E2E/QuickSettingsScenarioTest.ps1
+++ b/E2E/QuickSettingsScenarioTest.ps1
@@ -143,6 +143,7 @@ param (
 )
 .".\CheckInTest\Helper-library.ps1"
 InitializeTest 'QuickSettingsScenarioTesting'
+Import-QuickSettingsModules
 $voiceFocusExists = CheckVoiceFocusPolicy  
 if($voiceFocusExists -eq $false)
 {

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -65,7 +65,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
          #Retrieve video resolution from hash table
          $vdoResDetails= RetrieveValue($vdoRes)
          $powerProfileFolder = $currentPowerProfile -replace ' ', ''
-         $testFolderName = if ($useQuickSettings) { 'QuickSettingsCameraAppTest' } else { 'CameraAppTest' }
+         $testFolderName = if ($useQuickSettings) { 'CameraAppTestQS' } else { 'CameraAppTest' }
          $scenarioName = "$testFolderName\$powerProfileFolder\$camsnario\$vdoResDetails" 
 
       Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -52,7 +52,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
 {
    Write-Log -Message "Setting up Power Profile to $currentPowerProfile" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
    SetPowerProfileInSettingsPage -powerProfile $currentPowerProfile
-   Stop-Process -Name 'systemsettings'
+   CloseApp 'systemsettings'
 
    # Loop through Camera mode
    foreach($camsnario in $deviceData["CameraScenario"])

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -64,7 +64,9 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
          $startTime = Get-Date 
          #Retrieve video resolution from hash table
          $vdoResDetails= RetrieveValue($vdoRes)
-         $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
+         $powerProfileFolder = $currentPowerProfile -replace ' ', ''
+         $testFolderName = if ($useQuickSettings) { 'QuickSettingsCameraAppTest' } else { 'CameraAppTest' }
+         $scenarioName = "$testFolderName\$powerProfileFolder\$camsnario\$vdoResDetails" 
 
       Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
       
@@ -81,7 +83,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
       {   
          #Retrieve photo resolution from hash table 
          $ptoResDetails= RetrieveValue($ptoRes)       
-         $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails" 
+         $scenarioName = "$testFolderName\$powerProfileFolder\$camsnario\$vdoResDetails\$ptoResDetails" 
 
          Write-Log -Message "Setting up Photo Res to $ptoRes" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
 

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -12,6 +12,11 @@ param (
 
 InitializeTest 'ReleaseTest' $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer
 
+# Load Quick Settings modules on demand (OCR/WinRT deps may not be available everywhere)
+if ($useQuickSettings) {
+    Import-QuickSettingsModules
+}
+
 # Select the camera test function based on Quick Settings mode
 $CameraTestFunction = if ($useQuickSettings) { 'CameraAppTestQuickSettings' } else { 'CameraAppTest' }
 $logFileName = if ($useQuickSettings) { 'QuickSettingsCameraAppTest.txt' } else { 'CameraAppTest.txt' }

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -1,10 +1,11 @@
-﻿param ( 
+param ( 
    [string] $token = $null,
    [string] $SPId = $null,
    [string] $targetMepCameraVer = $null,
    [string] $targetMepAudioVer = $null,
    [string] $targetPerceptionCoreVer = $null,
-   [ValidateSet("Both", "PluggedInOnly", "UnpluggedOnly")][string] $runMode = $null
+   [ValidateSet("Both", "PluggedInOnly", "UnpluggedOnly")][string] $runMode = $null,
+   [string] $powerProfile = $null
 )
 .".\CheckInTest\Helper-library.ps1"
 
@@ -22,17 +23,36 @@ $filteredPhotoResolutions = Filter-Resolutions -requestedResolutions @() -availa
 # OneTime Setting- Open Camera App and set default setting to "Use system settings" 
 Set-SystemSettingsInCamera  >> "$pathLogsFolder\CameraAppTest.txt"
 
-# Loop through Camera mode
-foreach($camsnario in $deviceData["CameraScenario"])
-{  
-   # Loop through video resolutions
-   foreach ($vdoRes in $filteredVideoResolutions)
+# Determine power profiles to test: use user-specified profile or all available
+$powerProfilesToTest = if ($powerProfile) {
+   if ($deviceData["PowerProfiles"] -contains $powerProfile) {
+      @($powerProfile)
+   } else {
+      Write-Warning "Specified power profile '$powerProfile' is not available on this device. Available: $($deviceData['PowerProfiles'] -join ', ')"
+      Write-Log -Message "Power profile '$powerProfile' not available. Using all profiles." | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+      $deviceData["PowerProfiles"]
+   }
+} else {
+   $deviceData["PowerProfiles"]
+}
+
+foreach ($currentPowerProfile in $powerProfilesToTest)
+{
+   Write-Log -Message "Setting up Power Profile to $currentPowerProfile" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+   SetPowerProfileInSettingsPage -powerProfile $currentPowerProfile
+   Stop-Process -Name 'systemsettings'
+
+   # Loop through Camera mode
+   foreach($camsnario in $deviceData["CameraScenario"])
    {  
-      $initialSetupDone = "true" 
-      $startTime = Get-Date 
-      #Retrieve video resolution from hash table
-	   $vdoResDetails= RetrieveValue($vdoRes)
-      $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
+      # Loop through video resolutions
+      foreach ($vdoRes in $filteredVideoResolutions)
+      {
+         $initialSetupDone = "true" 
+         $startTime = Get-Date 
+         #Retrieve video resolution from hash table
+         $vdoResDetails= RetrieveValue($vdoRes)
+         $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
 
       Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
       
@@ -72,7 +92,8 @@ foreach($camsnario in $deviceData["CameraScenario"])
             $unpluggedLast = -1
             $pluggedInLast = -1
 
-            while ($true) {
+            while ($true)
+            {
                $batteryPercentage = Get-BatteryPercentage
                $chargingState = Get-ChargingState  # Fetch current charging state
 
@@ -92,7 +113,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                         $pluggedInLast++
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
-                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                         $batteryPercentage = Get-BatteryPercentage
                      }
                   } else {
@@ -105,7 +126,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
                      }
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   }
 
                   if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
@@ -144,7 +165,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                      $unpluggedLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
                      $devPowStat = "Unplugged"
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   } else {
                      Write-Host "Completed all Unplugged AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
                      break
@@ -164,7 +185,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
                      $pluggedInLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                      $devPowStat = "PluggedIn"
-                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
                   } else {
                      Write-Host "Completed all PluggedIn AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
                      break
@@ -184,6 +205,7 @@ foreach($camsnario in $deviceData["CameraScenario"])
             }
          } 
       }
+   }
    }
 }
 

--- a/E2E/ReleaseTest.ps1
+++ b/E2E/ReleaseTest.ps1
@@ -5,13 +5,20 @@ param (
    [string] $targetMepAudioVer = $null,
    [string] $targetPerceptionCoreVer = $null,
    [ValidateSet("Both", "PluggedInOnly", "UnpluggedOnly")][string] $runMode = $null,
-   [string] $powerProfile = $null
+   [string] $powerProfile = $null,
+   [switch] $useQuickSettings = $false
 )
 .".\CheckInTest\Helper-library.ps1"
 
 InitializeTest 'ReleaseTest' $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer
-$deviceData = GetDeviceDetails 
-Write-Log -Message "$deviceData" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+
+# Select the camera test function based on Quick Settings mode
+$CameraTestFunction = if ($useQuickSettings) { 'CameraAppTestQuickSettings' } else { 'CameraAppTest' }
+$logFileName = if ($useQuickSettings) { 'QuickSettingsCameraAppTest.txt' } else { 'CameraAppTest.txt' }
+Write-Log -Message "Using test function: $CameraTestFunction" | Out-Null
+
+$deviceData = GetDeviceDetails
+Write-Log -Message "$deviceData" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
 
 # Handle resolution filtering based on command line parameters
 # ReleaseTest always uses default strategic selection (max+min+720p for video, highest for photo)
@@ -21,7 +28,7 @@ $filteredVideoResolutions = Filter-Resolutions -requestedResolutions @() -availa
 $filteredPhotoResolutions = Filter-Resolutions -requestedResolutions @() -availableResolutions $deviceData["PhotoResolutions"] -resolutionType "photo"
 
 # OneTime Setting- Open Camera App and set default setting to "Use system settings" 
-Set-SystemSettingsInCamera  >> "$pathLogsFolder\CameraAppTest.txt"
+Set-SystemSettingsInCamera  >> "$pathLogsFolder\$logFileName"
 
 # Determine power profiles to test: use user-specified profile or all available
 $powerProfilesToTest = if ($powerProfile) {
@@ -29,7 +36,7 @@ $powerProfilesToTest = if ($powerProfile) {
       @($powerProfile)
    } else {
       Write-Warning "Specified power profile '$powerProfile' is not available on this device. Available: $($deviceData['PowerProfiles'] -join ', ')"
-      Write-Log -Message "Power profile '$powerProfile' not available. Using all profiles." | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+      Write-Log -Message "Power profile '$powerProfile' not available. Using all profiles." | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
       $deviceData["PowerProfiles"]
    }
 } else {
@@ -38,7 +45,7 @@ $powerProfilesToTest = if ($powerProfile) {
 
 foreach ($currentPowerProfile in $powerProfilesToTest)
 {
-   Write-Log -Message "Setting up Power Profile to $currentPowerProfile" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+   Write-Log -Message "Setting up Power Profile to $currentPowerProfile" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
    SetPowerProfileInSettingsPage -powerProfile $currentPowerProfile
    Stop-Process -Name 'systemsettings'
 
@@ -54,7 +61,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
          $vdoResDetails= RetrieveValue($vdoRes)
          $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails" 
 
-      Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+      Write-Log -Message "Setting up video Res to $vdoRes" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
       
       #skip the test if video resolution is not available. 
       $result = SetvideoResolutionInCameraApp $scenarioName $startTime $vdoRes
@@ -71,7 +78,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
          $ptoResDetails= RetrieveValue($ptoRes)       
          $scenarioName = "CameraAppTest\$camsnario\$vdoResDetails\$ptoResDetails" 
 
-         Write-Log -Message "Setting up Photo Res to $ptoRes" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
+         Write-Log -Message "Setting up Photo Res to $ptoRes" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
 
          #skip the test if photo resolution is not available. 
          $result = SetphotoResolutionInCameraApp $scenarioName $startTime $ptoRes
@@ -85,8 +92,8 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
          {  
             if($VF -ne "NA")
             {
-               Write-Log -Message "Setting up Voice Focus to $VF" | Out-File -FilePath "$pathLogsFolder\CameraAppTest.txt" -Append
-               VoiceFocusToggleSwitch $VF >> "$pathLogsFolder\CameraAppTest.txt"
+               Write-Log -Message "Setting up Voice Focus to $VF" | Out-File -FilePath "$pathLogsFolder\$logFileName" -Append
+               VoiceFocusToggleSwitch $VF >> "$pathLogsFolder\$logFileName"
             }
 
             $unpluggedLast = -1
@@ -113,7 +120,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
                         $pluggedInLast++
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
-                        CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                        & $CameraTestFunction -logFile $logFileName -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\$logFileName"
                         $batteryPercentage = Get-BatteryPercentage
                      }
                   } else {
@@ -126,7 +133,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
                         $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                         $devPowStat = "PluggedIn"
                      }
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     & $CameraTestFunction -logFile $logFileName -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\$logFileName"
                   }
 
                   if ($unpluggedLast -eq ($deviceData["ToggleAiEffect"].Count - 1) -and $pluggedInLast -eq ($deviceData["ToggleAiEffect"].Count - 1)) {
@@ -165,7 +172,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
                      $unpluggedLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$unpluggedLast]
                      $devPowStat = "Unplugged"
-                     CameraAppTest -logFile "CameraAppTest.txt" -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     & $CameraTestFunction -logFile $logFileName -token $token -SPId $SPId -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\$logFileName"
                   } else {
                      Write-Host "Completed all Unplugged AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
                      break
@@ -185,7 +192,7 @@ foreach ($currentPowerProfile in $powerProfilesToTest)
                      $pluggedInLast++
                      $togAiEfft = $deviceData["ToggleAiEffect"][$pluggedInLast]
                      $devPowStat = "PluggedIn"
-                     CameraAppTest -logFile "CameraAppTest.txt" -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\CameraAppTest.txt"
+                     & $CameraTestFunction -logFile $logFileName -initSetUpDone $initialSetupDone -powerProfile $currentPowerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\$logFileName"
                   } else {
                      Write-Host "Completed all PluggedIn AI effects for current combination: $camsnario | $vdoResDetails | $ptoResDetails | $VF" -ForegroundColor Green
                      break

--- a/E2E/ScenarioTest.ps1
+++ b/E2E/ScenarioTest.ps1
@@ -155,7 +155,7 @@ if($voiceFocusExists -eq $false)
 # Set up Power Profile
 Write-Log -Message "Setting up Power Profile to $powerProfile" | Out-File -FilePath "$pathLogsFolder\ScenarioTesting.txt" -Append
 SetPowerProfileInSettingsPage -powerProfile $powerProfile
-Stop-Process -Name 'systemsettings'
+CloseApp 'systemsettings'
 
 if($toggleAIEffects -eq "All")
 {

--- a/E2E/ScenarioTest.ps1
+++ b/E2E/ScenarioTest.ps1
@@ -136,7 +136,12 @@ param (
    [string] $ptoRes = "2.1 megapixels, 16 by 9 aspect ratio,  1920 by 1080 resolution",  # Default if not provided
 
    [ValidateSet("Pluggedin", "Unplugged")]
-   [string] $devPowStat = "Pluggedin"  # Default if not provided
+   [string] $devPowStat = "Pluggedin",  # Default if not provided
+
+   # Power Profile options: Best Power Efficiency, Balanced, Best Performance
+   # This parameter controls the Windows power mode setting used during the test
+   [ValidateSet("Best Power Efficiency", "Balanced", "Best Performance")]
+   [string] $powerProfile = "Balanced"  # Default if not provided
 
 )
 .".\CheckInTest\Helper-library.ps1"
@@ -146,6 +151,12 @@ if($voiceFocusExists -eq $false)
 {
    $VF = "NA"
 }
+
+# Set up Power Profile
+Write-Log -Message "Setting up Power Profile to $powerProfile" | Out-File -FilePath "$pathLogsFolder\ScenarioTesting.txt" -Append
+SetPowerProfileInSettingsPage -powerProfile $powerProfile
+Stop-Process -Name 'systemsettings'
+
 if($toggleAIEffects -eq "All")
 {
    $deviceData = GetDeviceDetails
@@ -153,8 +164,9 @@ if($toggleAIEffects -eq "All")
 }    
 foreach ($togAiEfft in $toggleAIEffects)
 {
-   CameraAppTest -token $token -SPId $SPId -logFile $logFile -initSetUpDone $initSetUpDone -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\ScenarioTesting.txt"
+   CameraAppTest -token $token -SPId $SPId -logFile $logFile -initSetUpDone $initSetUpDone -powerProfile $powerProfile -camsnario $camsnario -VF $VF -vdoRes $vdoRes -ptoRes $ptoRes -devPowStat $devPowStat -toggleEachAiEffect $togAiEfft >> "$pathLogsFolder\ScenarioTesting.txt"
 }
+
 [console]::beep(500,300)
 if($token.Length -ne 0 -and $SPId.Length -ne 0)
 {


### PR DESCRIPTION
## What changed?

Added OCR-based Studio Effects automation via the Windows Quick Settings panel:
- `OcrHelper.ps1` — Windows.Media.Ocr engine for detecting UI text not exposed by UI Automation
- `ScreenCapture.ps1` — DPI-aware region-based screenshot capture (right 40% of screen for flyout targeting)
- `StudioEffectsHandler.ps1` — Open/close Quick Settings, toggle effects with multi-offset click strategy and state verification
- `CameraAppTestQuickSettings.ps1` — Quick Settings variant of CameraAppTest
- `QuickSettingsScenarioTest.ps1` — Standalone scenario test entry point
- Updated `Helper-library.ps1` to dot-source new modules
- Updated `ReleaseTest.ps1` with `-useQuickSettings` switch for dynamic test function selection

## Why changed?

The Studio Effects flyout in Windows Quick Settings is NOT accessible via the UI Automation tree. To automate toggling AI camera effects (Background Blur, Eye Contact, Auto Framing, Portrait Light, Creative Filters) from Quick Settings, an OCR-based approach using `Windows.Media.Ocr.OcrEngine` was needed.

## How did you test the change?

- Verified PowerShell script syntax for all new files
- Validated OCR detection pipeline: screenshot → bitmap-to-SoftwareBitmap → OCR text extraction → coordinate mapping
- Tested Open-QuickSettings / Close-QuickSettings keyboard shortcut delivery
- Toggle click strategy tries multiple X-offsets (60, 45, 80, 100px from right edge) for DPI/resolution variance

## Dependencies

- Depends on PR #109 (resolution filtering)
- Depends on PR #110 (power profiles)

Split from PR #108.