### PR TITLE
 Added Cinematic framing and excluded eye contact for external Camera

### DIFF
--- a/E2E/CheckInTest/Camerae2eTest.ps1
+++ b/E2E/CheckInTest/Camerae2eTest.ps1
@@ -12,7 +12,7 @@ INPUT PARAMETERS:
 RETURN TYPE:
     - void
 #>
-function Camera-App-Playlist($devPowStat, $token, $SPId) 
+function Camera-App-Playlist($devPowStat, $token, $SPId, $CameraType) 
 {   
     $startTime = Get-Date    
     $ErrorActionPreference='Stop'
@@ -28,7 +28,7 @@ function Camera-App-Playlist($devPowStat, $token, $SPId)
         Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to toggle all effects On" -IsOutput
         ToggleAIEffectsInSettingsApp -AFVal "On" -AFSVal "False" -AFCVal "True" -PLVal "On" -BBVal "On" -BSVal "False" -BPVal "True" `
                                      -ECVal "On" -ECSVal "True" -ECTVal "False" -VFVal "On" `
-                                     -CF "On" -CFI "False" -CFA "False" -CFW "True"
+                                     -CF "On" -CFI "False" -CFA "False" -CFW "True" -CameraType $CameraType
                  
         #Open Camera App and set default setting to "Use system settings" 
         Set-SystemSettingsInCamera
@@ -108,7 +108,7 @@ function Camera-App-Playlist($devPowStat, $token, $SPId)
         Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function to Restore the default state for AI effects" -IsOutput
         ToggleAIEffectsInSettingsApp -AFVal "Off" -AFSVal "False" -AFCVal "False" -PLVal "Off" -BBVal "Off" -BSVal "False" -BPVal "False" `
                                      -ECVal "Off" -ECSVal "False" -ECTVal "False" -VFVal "Off" `
-                                     -CF "Off" -CFI "False" -CFA "False" -CFW "False"
+                                     -CF "Off" -CFI "False" -CFA "False" -CFW "False" -CameraType $CameraType
              
     }
     catch

--- a/E2E/CheckInTest/Camerae2eTest.ps1
+++ b/E2E/CheckInTest/Camerae2eTest.ps1
@@ -9,6 +9,7 @@ INPUT PARAMETERS:
     - devPowStat [string] :- The power state of the device (e.g., "PluggedIn", "OnBattery").
     - token [string] :- Authentication token required to control the smart plug.
     - SPId [string] :- Smart plug ID used to control device power states.
+    - CameraType [string] :- The type or identifier of the camera to be tested.
 RETURN TYPE:
     - void
 #>

--- a/E2E/CheckInTest_External_USB_Camera.ps1
+++ b/E2E/CheckInTest_External_USB_Camera.ps1
@@ -8,15 +8,15 @@ param (
 )
 
 .".\CheckInTest\Helper-library.ps1"
-InitializeTest 'Checkin-Test' $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer -CameraType "External Camera"
+InitializeTest 'Checkin-Test-External-Camera' $targetMepCameraVer $targetMepAudioVer $targetPerceptionCoreVer -CameraType "External Camera"
 foreach($devPowStat in "Pluggedin", "Unplugged")
 {  
-	foreach($testScenario in 'AF', 'BBS', 'BBP', 'PL', 'CF-I', 'CF-A', 'CF-W')
+	foreach($testScenario in 'AFS', 'AFC' , 'BBS', 'BBP', 'PL', 'CF-I', 'CF-A', 'CF-W')
 	{
 		SettingAppTest-Playlist -devPowStat $devPowStat -testScenario $testScenario -token $token -SPId $SPId -CameraType "External Camera" >> $pathLogsFolder\"$devPowStat-SettingAppTest.txt"
 	}
 
-	Camera-App-Playlist -devPowStat $devPowStat -token $token -SPId $SPId >> $pathLogsFolder\"$devPowStat-Camerae2eTest.txt"
+	Camera-App-Playlist -devPowStat $devPowStat -token $token -SPId $SPId -CameraType "External Camera" >> $pathLogsFolder\"$devPowStat-Camerae2eTest.txt"
 }
 
 

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -196,7 +196,7 @@ INPUT PARAMETERS:
 RETURN TYPE:
     - void (Performs UI interactions to toggle camera and audio effects without returning a value.)
 #>
-Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVal,$BPVal,$ECVal,$ECSVal,$ECTVal,$VFVal,$CF,$CFI,$CFA,$CFW)
+Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVal,$BPVal,$ECVal,$ECSVal,$ECTVal,$VFVal,$CF,$CFI,$CFA,$CFW,$CameraType)
 {    
      Write-Log -Message "Entering ToggleAIEffectsInSettingsApp function" -IsOutput
      
@@ -211,7 +211,10 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
 
      Write-Log -Message "Toggle camera effects in setting Page" -IsOutput
      FindAndSetValue $ui ToggleSwitch "Automatic framing" $AFVal
-     FindAndSetValue $ui ToggleSwitch "Eye contact" $ECVal
+     if($CameraType -ne "External Camera")
+     {
+        FindAndSetValue $ui ToggleSwitch "Eye contact" $ECVal
+     }
      FindAndSetValue $ui ToggleSwitch "Background effects" $BBVal
 
      if($BBVal -eq "On")
@@ -233,10 +236,13 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
            FindAndSetValue $ui RadioButton "Watercolor" $CFW
 
         }
-        if($ECVal -eq "On")
-        { 
-           FindAndSetValue $ui RadioButton "Standard" $ECSVal
-           FindAndSetValue $ui RadioButton "Teleprompter" $ECTVal
+        if($ECVal -eq "On") 
+        {  
+           if($CameraType -ne "External Camera")
+           {
+              FindAndSetValue $ui RadioButton "Standard" $ECSVal
+              FindAndSetValue $ui RadioButton "Teleprompter" $ECTVal
+           }
         }
         $wse8480PolicyState = Check8480Policy
         if ($wse8480PolicyState -eq $true)

--- a/E2E/Library/SettingsAppHandlers.ps1
+++ b/E2E/Library/SettingsAppHandlers.ps1
@@ -193,6 +193,7 @@ INPUT PARAMETERS:
     - CFI [string] :- Toggle value for Illustrated Creative Filter.
     - CFA [string] :- Toggle value for Animated Creative Filter.
     - CFW [string] :- Toggle value for Watercolor Creative Filter.
+    - CameraType [string] :- The type or identifier of the camera to be tested.
 RETURN TYPE:
     - void (Performs UI interactions to toggle camera and audio effects without returning a value.)
 #>
@@ -255,10 +256,12 @@ Function ToggleAIEffectsInSettingsApp($AFVal,$AFSVal,$AFCVal,$PLVal,$BBVal,$BSVa
            }
 		}
      }
-     
-     
      #open microphone effects page and turn all effects off
-     VoiceFocusToggleSwitch $VFVal
+     if($CameraType -ne "External Camera")
+     {
+        VoiceFocusToggleSwitch $VFVal
+     }
+     
           
      #close settings app
      CloseApp 'systemsettings'


### PR DESCRIPTION
## What changed?
Added Cinematic framing scenario and removed Eye contact option for External Camera Testing
## Why changed?

## How did you test the change?
<img width="221" height="89" alt="image" src="https://github.com/user-attachments/assets/4cdea73b-b7b4-4f96-a544-2f8068423445" />

## Related Issues (if any):

